### PR TITLE
Bugfixes nov 2025

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -11,6 +11,7 @@ env ALLOWED_HOSTS;
 env DISABLE_SSL_VERIFY;
 env LOG_VERBOSE;
 env RESOLVE_TTL;
+env TMP_RETENTION_SECS;
 
 worker_processes auto;
 
@@ -22,9 +23,9 @@ http {
   include       mime.types;
   default_type  application/octet-stream;
 
-  sendfile      on;
-  tcp_nopush    on;
-  tcp_nodelay   on;
+  sendfile        on;
+  tcp_nopush      on;
+  tcp_nodelay     on;
   keepalive_timeout 65;
 
   # Lua module paths (for resty.http)
@@ -39,58 +40,113 @@ http {
   lua_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
   lua_ssl_verify_depth 5;
 
-  # Logs to Docker
+  # Logs to Docker (now with request id, decision, and xcache)
   log_format main '$remote_addr - $remote_user [$time_local] "$request" '
                   '$status $body_bytes_sent "$http_referer" '
                   '"$http_user_agent" "$http_range" '
-                  'rt=$request_time up_rt=$upstream_response_time';
+                  'rt=$request_time up_rt=$upstream_response_time '
+                  'rid=$request_id decision=$sc_decision xcache=$sent_http_x_cache';
+
   access_log /dev/stdout main;
   error_log  /dev/stderr info;
 
+  # Declare $sc_decision at http level so it's usable in log_format
+  map $request_id $sc_decision { default ""; }
+
   # Shared dicts for streamcache
-  lua_shared_dict inflight  10m; # prevent duplicate full fetches
-  lua_shared_dict access    50m; # last-access timestamps (LRU)
-  lua_shared_dict resolved  10m; # kept for optional hints
-  lua_shared_dict progress  10m; # follower progress
-  lua_shared_dict totals    10m; # total size hints
+  lua_shared_dict inflight 10m;  # prevent duplicate full fetches
+  lua_shared_dict access   50m;  # last-access timestamps (LRU)
+  lua_shared_dict resolved 10m;  # kept for optional hints
+  lua_shared_dict progress 10m;  # follower progress
+  lua_shared_dict totals   10m;  # total size hints
 
   client_max_body_size 0;
 
-  # --- Janitor (your existing logic; compact form) ---
+  # --- Janitor + tmp-janitor ---
   init_worker_by_lua_block {
     local ngx = ngx
     local access = ngx.shared.access
+    local inflight = ngx.shared.inflight
+    local progress = ngx.shared.progress
+
     local CACHE_DIR = "/var/cache/streamcache/files"
     local META_DIR  = "/var/cache/streamcache/meta"
-    local function b2human(n) if not n or n<0 then return "0 B" end local u={"B","KB","MB","GB","TB","PB"} local i=1 while n>=1024 and i<#u do n=n/1024 i=i+1 end return string.format("%.2f %s", n, u[i]) end
+    local TMP_DIR   = "/var/cache/streamcache/tmp"
+
+    local function b2human(n)
+      if not n or n < 0 then return "0 B" end
+      local u={"B","KB","MB","GB","TB","PB"} local i=1
+      while n >= 1024 and i < #u do n = n/1024; i = i + 1 end
+      return string.format("%.2f %s", n, u[i])
+    end
+
     local VERBOSE = (os.getenv("LOG_VERBOSE") == "1")
-    local function file_size(p) local f=io.open(p,"rb"); if not f then return 0 end local sz=f:seek("end"); f:close(); return sz or 0 end
-    local function parse_meta(p) local f=io.open(p,"rb"); if not f then return nil end local size,last=nil,nil for line in f:lines() do local k,v=line:match("^([a-z_]+)=(.+)$") if k=="size" then size=tonumber(v) elseif k=="last_access" then last=tonumber(v) end end f:close(); return size,last end
+
+    local function file_size(p)
+      local f = io.open(p, "rb")
+      if not f then return 0 end
+      local sz = f:seek("end"); f:close()
+      return sz or 0
+    end
+
+    local function parse_meta(p)
+      local f = io.open(p, "rb")
+      if not f then return nil end
+      local size, last = nil, nil
+      for line in f:lines() do
+        local k,v = line:match("^([a-z_]+)=(.+)$")
+        if k == "size" then size = tonumber(v)
+        elseif k == "last_access" then last = tonumber(v)
+        end
+      end
+      f:close(); return size, last
+    end
+
+    local function file_mtime(p)
+      local h = io.popen('stat -c %Y "'..p..'" 2>/dev/null')
+      if not h then return nil end
+      local t = h:read("*l"); h:close()
+      return tonumber(t)
+    end
+
     local function janitor(premature)
       if premature then return end
       local MAX = tonumber(os.getenv("CACHE_MAX_BYTES") or "") or (500 * 1024^3)
       local LOW = tonumber(os.getenv("CACHE_LOW_WATERMARK_BYTES") or "") or (450 * 1024^3)
       local t0 = ngx.now()
+
       os.execute("mkdir -p " .. CACHE_DIR .. " " .. META_DIR)
+
       local files, total = {}, 0
       local p = io.popen("ls -1 " .. CACHE_DIR .. " 2>/dev/null")
-      if p then for name in p:lines() do
-        local key=name
-        local path=CACHE_DIR.."/"..name
-        local meta_path=META_DIR.."/"..key..".meta"
-        local size,last = parse_meta(meta_path)
-        if not size then size = file_size(path) end
-        if not last then last = access:get(key) or 0 end
-        files[#files+1] = {key=key, path=path, meta=meta_path, size=size, last=last}
-        total = total + (size or 0)
-      end p:close() end
-      if VERBOSE then
-        ngx.log(ngx.INFO, string.format("[streamcache] janitor check: total=%s (%d bytes), max=%s, low=%s, files=%d", b2human(total), total, b2human(MAX), b2human(LOW), #files))
-      else
-        ngx.log(ngx.NOTICE, string.format("[streamcache] janitor: total=%s, max=%s, low=%s", b2human(total), b2human(MAX), b2human(LOW)))
+      if p then
+        for name in p:lines() do
+          local key = name
+          local path = CACHE_DIR .. "/" .. name
+          local meta_path = META_DIR .. "/" .. key .. ".meta"
+          local size, last = parse_meta(meta_path)
+          if not size then size = file_size(path) end
+          if not last then last = access:get(key) or 0 end
+          files[#files+1] = {key=key, path=path, meta=meta_path, size=size, last=last}
+          total = total + (size or 0)
+        end
+        p:close()
       end
+
+      if VERBOSE then
+        ngx.log(ngx.INFO, string.format(
+          "[streamcache] janitor check: total=%s (%d bytes), max=%s, low=%s, files=%d",
+          b2human(total), total, b2human(MAX), b2human(LOW), #files))
+      else
+        ngx.log(ngx.NOTICE, string.format(
+          "[streamcache] janitor: total=%s, max=%s, low=%s",
+          b2human(total), b2human(MAX), b2human(LOW)))
+      end
+
       if total <= MAX then return end
+
       table.sort(files, function(a,b) return (a.last or 0) < (b.last or 0) end)
+
       local removed_files, removed_bytes = 0, 0
       for _,f in ipairs(files) do
         if total <= LOW then break end
@@ -98,17 +154,59 @@ http {
         total = total - (f.size or 0)
         removed_files = removed_files + 1
         removed_bytes = removed_bytes + (f.size or 0)
-        if VERBOSE then ngx.log(ngx.INFO, string.format("[streamcache] evict: key=%s size=%s", f.key, b2human(f.size or 0))) end
+        if VERBOSE then
+          ngx.log(ngx.INFO, string.format("[streamcache] evict: key=%s size=%s",
+            f.key, b2human(f.size or 0)))
+        end
       end
-      ngx.log(ngx.NOTICE, string.format("[streamcache] eviction done in %.2fs: removed %d (%s), new total=%s", ngx.now() - t0, removed_files, b2human(removed_bytes), b2human(total)))
+
+      ngx.log(ngx.NOTICE, string.format(
+        "[streamcache] eviction done in %.2fs: removed %d (%s), new total=%s",
+        ngx.now() - t0, removed_files, b2human(removed_bytes), b2human(total)))
     end
+
+    -- tmp-janitor: purge orphaned .part files older than TMP_RETENTION_SECS and not inflight
+    local function janitor_tmp(premature)
+      if premature then return end
+      local keep = tonumber(os.getenv("TMP_RETENTION_SECS") or "") or 86400 -- 24h default
+      os.execute("mkdir -p " .. TMP_DIR)
+      local p = io.popen("ls -1 " .. TMP_DIR .. " 2>/dev/null")
+      if not p then return end
+      local removed = 0
+      for name in p:lines() do
+        local key = name:match("^(%x+)%.part$")
+        if key then
+          local path = TMP_DIR .. "/" .. name
+          local mt   = file_mtime(path) or 0
+          local age  = ngx.now() - mt
+          local infl = inflight:get(key)
+          local prog = progress:get(key)
+          if (not infl) and (not prog or prog == 0) and age > keep then
+            os.remove(path); removed = removed + 1
+            if VERBOSE then ngx.log(ngx.INFO, "[streamcache] tmp-janitor removed ", name) end
+          end
+        end
+      end
+      p:close()
+      if removed > 0 then
+        ngx.log(ngx.NOTICE, "[streamcache] tmp-janitor purged ", removed, " stale .part files")
+      end
+    end
+
     local interval = tonumber(os.getenv("CACHE_JANITOR_INTERVAL") or "") or 60
+
     if ngx.worker.id() == 0 then
       local MAX = tonumber(os.getenv("CACHE_MAX_BYTES") or "") or (500 * 1024^3)
       local LOW = tonumber(os.getenv("CACHE_LOW_WATERMARK_BYTES") or "") or (450 * 1024^3)
-      ngx.log(ngx.NOTICE, string.format("[streamcache] start: max=%s (%d), low=%s (%d), interval=%ds, verbose=%s", b2human(MAX), MAX, b2human(LOW), LOW, interval, tostring(VERBOSE)))
+      ngx.log(ngx.NOTICE, string.format(
+        "[streamcache] start: max=%s (%d), low=%s (%d), interval=%ds, verbose=%s",
+        b2human(MAX), MAX, b2human(LOW), LOW, interval, tostring(VERBOSE)))
+
       local ok, err = ngx.timer.every(interval, janitor)
       if not ok then ngx.log(ngx.ERR, "janitor timer failed: ", err) end
+
+      local ok2, err2 = ngx.timer.every(interval, janitor_tmp)
+      if not ok2 then ngx.log(ngx.ERR, "tmp-janitor timer failed: ", err2) end
     elseif VERBOSE then
       ngx.log(ngx.INFO, "[streamcache] worker " .. ngx.worker.id() .. " not leader; janitor disabled")
     end

--- a/conf/streamcache.lua
+++ b/conf/streamcache.lua
@@ -5,19 +5,48 @@ local ngx  = ngx
 local os   = os
 local http = require "resty.http"
 
+
+
+-- Safe setter for nginx vars (no-ops outside request phases)
+local function set_var_safe(name, value)
+  local phase = ngx.get_phase()
+  if phase == "rewrite" or phase == "access" or phase == "content" or phase == "log" then
+    pcall(function() ngx.var[name] = value end)
+  end
+end
+
 -- ===================== Config (via env) =====================
 local VERBOSE               = (os.getenv("LOG_VERBOSE") == "1")
-local RANGE_TEE_THRESHOLD   = tonumber(os.getenv("RANGE_TEE_THRESHOLD") or "") or (5 * 1024 * 1024) -- 5 MiB
-local PROGRESS_FLUSH_BYTES  = tonumber(os.getenv("PROGRESS_FLUSH_BYTES") or "") or 262144                -- 256 KiB
-local FOLLOWER_WAIT_MAX     = tonumber(os.getenv("FOLLOWER_WAIT_MAX") or "") or 600                      -- seconds
-local FOLLOWER_POLL_MS      = tonumber(os.getenv("FOLLOWER_POLL_MS") or "") or 50                        -- ms
+local RANGE_TEE_THRESHOLD   = tonumber(os.getenv("RANGE_TEE_THRESHOLD")   or "") or (5 * 1024 * 1024) -- 5 MiB
+local PROGRESS_FLUSH_BYTES  = tonumber(os.getenv("PROGRESS_FLUSH_BYTES")  or "") or 262144            -- 256 KiB
+local FOLLOWER_WAIT_MAX     = tonumber(os.getenv("FOLLOWER_WAIT_MAX")     or "") or 600              -- seconds
+local FOLLOWER_POLL_MS      = tonumber(os.getenv("FOLLOWER_POLL_MS")      or "") or 50               -- ms
+-- New: short startup wait for followers so we don't open a duplicate upstream
+local FOLLOWER_START_WAIT_MS= tonumber(os.getenv("FOLLOWER_START_WAIT_MS")or "") or 750              -- ms
+-- New: batch client flushes to reduce syscall and allocator pressure
+local CLIENT_FLUSH_BYTES    = tonumber(os.getenv("CLIENT_FLUSH_BYTES")    or "") or (1 * 1024 * 1024) -- 1 MiB
+-- New: how long to retain the known TOTAL size (refresh while downloading)
+local TOTALS_TTL_SECS       = tonumber(os.getenv("TOTALS_TTL_SECS")       or "") or 86400            -- 24h
 local SSL_VERIFY            = (os.getenv("DISABLE_SSL_VERIFY") ~= "1")
+
+-- Correlation id and structured logging helper
+local RID = ngx.var.request_id or tostring(ngx.now())
+local function jlog(level, event, fields)
+  if not VERBOSE then return end
+  fields = fields or {}
+  fields.rid = RID
+  local buf = {}
+  for k,v in pairs(fields) do
+    buf[#buf+1] = string.format('"%s":"%s"', k, tostring(v))
+  end
+  ngx.log(level, "[streamcache] ", event, " {", table.concat(buf, ","), "}")
+end
 
 -- ===================== Helpers =====================
 local function b2human(n)
   if not n or n < 0 then return "0 B" end
   local u = {"B","KB","MB","GB","TB","PB"}; local i=1
-  while n>=1024 and i<#u do n = n/1024; i = i+1 end
+  while n >= 1024 and i < #u do n = n/1024; i = i+1 end
   return string.format("%.2f %s", n, u[i])
 end
 
@@ -30,6 +59,7 @@ local function write_meta(key, size, last)
   f:write("last_access=" .. tostring(last or ngx.now()) .. "\n")
   f:close()
 end
+
 local function b64url_decode(s)
   s = s:gsub("-", "+"):gsub("_", "/")
   local pad = #s % 4
@@ -37,8 +67,14 @@ local function b64url_decode(s)
   return ngx.decode_base64(s)
 end
 
-local function file_exists(p) local f=io.open(p,"rb"); if f then f:close(); return true end return false end
-local function file_size(p)  local f=io.open(p,"rb"); if not f then return 0 end local sz=f:seek("end"); f:close(); return sz or 0 end
+local function file_exists(p)
+  local f=io.open(p,"rb"); if f then f:close(); return true end; return false
+end
+
+local function file_size(p)
+  local f=io.open(p,"rb"); if not f then return 0 end; local sz=f:seek("end"); f:close(); return sz or 0
+end
+
 local function key_from_url(u) return ngx.md5(u) end
 
 -- URL parsing
@@ -49,6 +85,7 @@ local function split_hostport(authority, scheme)
   h,p = authority:match("^([^:]+):(%d+)$"); if h then return h, tonumber(p) end
   return authority, (scheme=="https" and 443 or 80)
 end
+
 local function parse_url(u)
   if not u then return nil end
   local scheme, rest = u:match("^(https?)://(.+)$"); if not scheme then return nil end
@@ -62,15 +99,15 @@ end
 local function resolve_location(current, scheme, host, loc)
   if not loc or loc == "" then return nil end
   if loc:match("^https?://") then return loc end
-  if loc:match("^//") then return scheme .. ":" .. loc end
+  if loc:match("^//")       then return scheme .. ":" .. loc end
   if loc:match("^[^/]+:%d+/.") or loc:match("^[^/]+/") then return scheme .. "://" .. loc end
-  if loc:sub(1,1) == "/" then return scheme .. "://" .. host .. loc end
+  if loc:sub(1,1) == "/"   then return scheme .. "://" .. host .. loc end
   local base = current:match("^(https?://[^?]+)")
-  local dir = base and base:match("(.*/)") or (scheme .. "://" .. host .. "/")
+  local dir  = base and base:match("(.*/)") or (scheme .. "://" .. host .. "/")
   return dir .. loc
 end
 
-local function tclone(t) local o={}; if not t then return o end for k,v in pairs(t) do o[k]=v end return o end
+local function tclone(t) local o={}; if not t then return o end; for k,v in pairs(t) do o[k]=v end; return o end
 
 local function build_client_like_headers(host_header, orig_url)
   local ch = ngx.req.get_headers()
@@ -113,14 +150,21 @@ local function fetch_origin_headers(final_url, hdrs)
 end
 
 -- ===================== Shared dicts =====================
-local inflight  = ngx.shared.inflight
-local access    = ngx.shared.access
-local resolved  = ngx.shared.resolved   -- kept for future hints
-local progress  = ngx.shared.progress
-local totals    = ngx.shared.totals
+local inflight = ngx.shared.inflight
+local access   = ngx.shared.access
+local resolved = ngx.shared.resolved -- kept for future hints
+local progress = ngx.shared.progress
+local totals   = ngx.shared.totals
+
+-- Refresh helper: keep the expected total alive during long/throttled downloads
+local function refresh_totals(key, size)
+  if not key or not size or size <= 0 then return end
+  totals:set(key, size, TOTALS_TTL_SECS) -- set() refreshes TTL
+end
 
 -- ===================== No-cache streamer (far-seek passthrough & HEAD) =====================
 local function stream_no_cache(url, normalize_200_when_no_client_range)
+  set_var_safe("sc_decision", (ngx.var.sc_decision ~= "" and ngx.var.sc_decision) or "MISS_NO_CACHE")
   local scheme, host, port, path, host_header = parse_url(url)
   if not scheme then return ngx.exit(ngx.HTTP_BAD_GATEWAY) end
 
@@ -136,6 +180,7 @@ local function stream_no_cache(url, normalize_200_when_no_client_range)
     end
     return true
   end
+
   if not connect_to(host, port, scheme) then httpc:close(); return ngx.exit(ngx.HTTP_BAD_GATEWAY) end
 
   local ch = ngx.req.get_headers()
@@ -166,8 +211,13 @@ local function stream_no_cache(url, normalize_200_when_no_client_range)
   local client_sent_range = (ch["Range"] ~= nil)
   local hl = {}; for k,v in pairs(res.headers or {}) do hl[string.lower(k)] = v end
   local total_size = nil
-  if hl["content-range"] then local s0,e0,t0 = hl["content-range"]:match("^bytes%s+(%d+)%-(%d+)%/(%d+)$"); if t0 then total_size = tonumber(t0) end end
-  if not total_size and hl["content-length"] and res.status == 200 then total_size = tonumber(hl["content-length"]) end
+  if hl["content-range"] then
+    local s0,e0,t0 = hl["content-range"]:match("^bytes%s+(%d+)%-(%d+)/(%d+)$")
+    if t0 then total_size = tonumber(t0) end
+  end
+  if not total_size and hl["content-length"] and res.status == 200 then
+    total_size = tonumber(hl["content-length"])
+  end
 
   local hcopy = {}
   for k,v in pairs(res.headers or {}) do
@@ -175,7 +225,7 @@ local function stream_no_cache(url, normalize_200_when_no_client_range)
     if kl ~= "transfer-encoding" and kl ~= "connection" and kl ~= "keep-alive"
        and kl ~= "proxy-authenticate" and kl ~= "proxy-authorization"
        and kl ~= "te" and kl ~= "trailer" and kl ~= "upgrade"
-       and kl ~= "location" then  -- never expose redirects
+       and kl ~= "location" then -- never expose redirects
       hcopy[k] = v
     end
   end
@@ -184,34 +234,47 @@ local function stream_no_cache(url, normalize_200_when_no_client_range)
 
   if normalize_200_when_no_client_range and (not client_sent_range) and res.status == 206 then
     hcopy["Content-Range"] = nil
-    if total_size and total_size > 0 then hcopy["Content-Length"] = tostring(total_size) else hcopy["Content-Length"] = nil end
+    if total_size and total_size > 0 then
+      hcopy["Content-Length"] = tostring(total_size)
+    else
+      hcopy["Content-Length"] = nil
+    end
     ngx.status = ngx.HTTP_OK
   else
     ngx.status = res.status
   end
+
   for k,v in pairs(hcopy) do ngx.header[k]=v end
   ngx.send_headers()
 
+  -- Batch client flushes
+  local flushed = 0
   if res.body_reader then
     while true do
       local chunk, cerr = res.body_reader(32768)
       if cerr then ngx.log(ngx.WARN,"[streamcache] nocache read error: ", tostring(cerr)); httpc:close(); return ngx.exit(ngx.HTTP_BAD_GATEWAY) end
       if not chunk then break end
       local okp = pcall(ngx.print, chunk)
-      if okp then ngx.flush(true) end
+      if okp then
+        flushed = flushed + #chunk
+        if flushed >= CLIENT_FLUSH_BYTES then ngx.flush(true); flushed = 0 end
+      end
     end
   elseif res.body then
     local okp = pcall(ngx.print, res.body); if okp then ngx.flush(true) end
   end
-
+  -- Final flush
+  ngx.flush(true)
   httpc:close()
   return
 end
 
 -- HEAD helper: follow redirects; never expose Location; no body
 local function head_no_cache(url)
+  set_var_safe("sc_decision", "HEAD_NOCACHE")
   local scheme, host, port, path, host_header = parse_url(url)
   if not scheme then return ngx.exit(ngx.HTTP_BAD_GATEWAY) end
+
   local httpc = http.new()
   httpc:set_timeouts(3000, 3000, 3000)
 
@@ -224,9 +287,10 @@ local function head_no_cache(url)
     end
     return true
   end
-  if not connect_to(host, port, scheme) then httpc:close(); return ngx.exit(ngx.HTTP_BAD_GATEWAY) end
 
+  if not connect_to(host, port, scheme) then httpc:close(); return ngx.exit(ngx.HTTP_BAD_GATEWAY) end
   local headers = build_client_like_headers(host_header, url)
+
   local hops, res, rerr = 0, nil, nil
   while true do
     res, rerr = httpc:request{ method = "HEAD", path = path, headers = headers }
@@ -270,8 +334,12 @@ local function head_no_cache(url)
   return
 end
 
--- ===================== Tee: upstream -> client + file =====================
-local function tee_stream(final_url, dest_path, key, use_range_0, orig_url_for_ref)
+-- ===================== Tee: upstream -> client + file (strict commit) =====================
+-- send_to_client = true (default): original behavior (sets headers & streams to client)
+-- send_to_client = false        : writer-only mode (no client headers/prints); just writes .part & updates progress/totals
+local function tee_stream(final_url, dest_path, key, use_range_0, orig_url_for_ref, send_to_client)
+  if send_to_client == nil then send_to_client = true end
+  set_var_safe("sc_decision", "MISS_TEE")
   final_url = (final_url or ""):gsub("^%s+", ""):gsub("[%s\r\n]+$", "")
   local scheme, host, port, path, host_header = parse_url(final_url)
   if not scheme then ngx.log(ngx.WARN,"[streamcache] tee parse failed url=",tostring(final_url)); inflight:delete(key); return ngx.exit(ngx.HTTP_BAD_GATEWAY) end
@@ -288,13 +356,25 @@ local function tee_stream(final_url, dest_path, key, use_range_0, orig_url_for_r
     end
     return true
   end
+
   if not connect_to(host, port, scheme) then httpc:close(); inflight:delete(key); return ngx.exit(ngx.HTTP_BAD_GATEWAY) end
 
-  local ch = ngx.req.get_headers()
-  local headers = build_client_like_headers(host_header, orig_url_for_ref)
-  if ch["Range"] and ch["Range"] ~= "" then headers["Range"] = ch["Range"]
-  elseif use_range_0 then headers["Range"] = "bytes=0-"
-  else headers["Range"] = nil end
+  local headers
+  if send_to_client then
+    headers = build_client_like_headers(host_header, orig_url_for_ref)
+    local ch = ngx.req.get_headers()
+    if ch["Range"] and ch["Range"] ~= "" then
+      headers["Range"] = ch["Range"]
+    elseif use_range_0 then
+      headers["Range"] = "bytes=0-"
+    else
+      headers["Range"] = nil
+    end
+  else
+    -- writer-only: decide Range solely by policy, not by request headers
+    headers = { ["Host"] = host_header, ["User-Agent"] = "EmbyStreamCache/1.0" }
+    if use_range_0 then headers["Range"] = "bytes=0-" end
+  end
 
   local hops, res, rerr = 0, nil, nil
   while true do
@@ -332,59 +412,62 @@ local function tee_stream(final_url, dest_path, key, use_range_0, orig_url_for_r
     end
   end
 
-  -- Parse totals
+  -- Parse totals (size hint)
   local hl = {}; for k,v in pairs(res.headers or {}) do hl[string.lower(k)] = v end
   local total_size = nil
-  if hl["content-range"] then local s0,e0,t0 = hl["content-range"]:match("^bytes%s+(%d+)%-(%d+)%/(%d+)$"); if t0 then total_size = tonumber(t0) end end
-  if not total_size and hl["content-length"] and res.status == 200 then total_size = tonumber(hl["content-length"]) end
-  if total_size and total_size > 0 then totals:set(key, total_size, 900) end
+  if hl["content-range"] then
+    local s0,e0,t0 = hl["content-range"]:match("^bytes%s+(%d+)%-(%d+)/(%d+)$")
+    if t0 then total_size = tonumber(t0) end
+  end
+  if not total_size and hl["content-length"] and res.status == 200 then
+    total_size = tonumber(hl["content-length"])
+  end
+  if total_size and total_size > 0 then refresh_totals(key, total_size) end
 
-  -- Prepare response headers to client; normalize 206->200 if client didn't ask Range
-  local client_sent_range = (ch["Range"] ~= nil)
-  local hcopy = {}
-  for k,v in pairs(res.headers or {}) do
-    local kl = string.lower(k)
-    if kl ~= "transfer-encoding" and kl ~= "connection" and kl ~= "keep-alive"
-       and kl ~= "proxy-authenticate" and kl ~= "proxy-authorization"
-       and kl ~= "te" and kl ~= "trailer" and kl ~= "upgrade"
-       and kl ~= "location" then
-      hcopy[k] = v
+  -- Prepare response headers to client (only if send_to_client); normalize 206->200 if no client Range
+  if send_to_client then
+    local ch = ngx.req.get_headers()
+    local client_sent_range = (ch["Range"] ~= nil)
+    local hcopy = {}
+    for k,v in pairs(res.headers or {}) do
+      local kl = string.lower(k)
+      if kl ~= "transfer-encoding" and kl ~= "connection" and kl ~= "keep-alive"
+         and kl ~= "proxy-authenticate" and kl ~= "proxy-authorization"
+         and kl ~= "te" and kl ~= "trailer" and kl ~= "upgrade"
+         and kl ~= "location" then
+        hcopy[k] = v
+      end
     end
+    hcopy["Accept-Ranges"] = "bytes"
+    if (not client_sent_range) and res.status == 206 then
+      hcopy["Content-Range"] = nil
+      if total_size and total_size > 0 then
+        hcopy["Content-Length"] = tostring(total_size)
+      else
+        hcopy["Content-Length"] = nil
+      end
+      ngx.status = ngx.HTTP_OK
+    else
+      ngx.status = res.status
+    end
+    for k,v in pairs(hcopy) do ngx.header[k] = v end
+    ngx.send_headers()
   end
-  hcopy["Accept-Ranges"] = "bytes"
-
-  if (not client_sent_range) and res.status == 206 then
-    hcopy["Content-Range"] = nil
-    if total_size and total_size > 0 then hcopy["Content-Length"] = tostring(total_size) else hcopy["Content-Length"] = nil end
-    ngx.status = ngx.HTTP_OK
-  else
-    ngx.status = res.status
-  end
-  for k,v in pairs(hcopy) do ngx.header[k] = v end
-  ngx.send_headers()
 
   -- Open temp file & tee (with no-cache fallback)
   os.execute("mkdir -p /var/cache/streamcache/tmp")
   local tmp = "/var/cache/streamcache/tmp/" .. key .. ".part"
+  os.remove(tmp) -- best-effort cleanup from prior crashes
   local f = io.open(tmp, "wb")
   if not f then
-    ngx.log(ngx.ERR,"[streamcache] tee cannot open temp: ", tmp, " ; falling back to streaming without cache")
-    if res.body_reader then
-      while true do
-        local chunk, cerr = res.body_reader(32768)
-        if cerr then ngx.log(ngx.WARN,"[streamcache] read error (nocache fallback): ", tostring(cerr)); httpc:close(); inflight:delete(key); return ngx.exit(ngx.HTTP_BAD_GATEWAY) end
-        if not chunk then break end
-        local okp = pcall(ngx.print, chunk); if okp then ngx.flush(true) end
-      end
-    elseif res.body then
-      local okp = pcall(ngx.print, res.body); if okp then ngx.flush(true) end
-    end
+    ngx.log(ngx.ERR,"[streamcache] tee cannot open temp: ", tmp, " ; falling back")
     httpc:close(); inflight:delete(key); return
   end
 
   local total = 0
   local last_report = 0
-  local client_alive = true
+  local client_alive = send_to_client
+  local flushed = 0
 
   if res.body_reader then
     while true do
@@ -392,34 +475,90 @@ local function tee_stream(final_url, dest_path, key, use_range_0, orig_url_for_r
       if cerr then ngx.log(ngx.WARN,"[streamcache] tee read error: ",tostring(cerr)); f:close(); os.remove(tmp); httpc:close(); inflight:delete(key); return ngx.exit(ngx.HTTP_BAD_GATEWAY) end
       if not chunk then break end
       total = total + #chunk
-      f:write(chunk)
-      if (total - last_report) >= PROGRESS_FLUSH_BYTES then
-        f:flush(); progress:set(key, total, 900); last_report = total
+      local okw, errw = f:write(chunk)
+      if not okw then
+        ngx.log(ngx.ERR,"[streamcache] write failed: ", tostring(errw), " rid=", RID)
+        f:close(); os.remove(tmp); httpc:close(); inflight:delete(key)
+        return ngx.exit(ngx.HTTP_BAD_GATEWAY)
       end
-      if client_alive then local okp = pcall(ngx.print, chunk); if not okp then client_alive=false else ngx.flush(true) end end
+      if (total - last_report) >= PROGRESS_FLUSH_BYTES then
+        local okf, errf = pcall(function() return f:flush() end)
+        if not okf then ngx.log(ngx.WARN,"[streamcache] flush failed: ", tostring(errf)) end
+        progress:set(key, total, 900); last_report = total
+        local exp = totals:get(key); if exp then refresh_totals(key, tonumber(exp)) end
+      end
+      if client_alive then
+        local okp = pcall(ngx.print, chunk)
+        if not okp then
+          client_alive=false
+        else
+          flushed = flushed + #chunk
+          if flushed >= CLIENT_FLUSH_BYTES then ngx.flush(true); flushed = 0 end
+        end
+      end
     end
   elseif res.body then
     total = #res.body
-    f:write(res.body); f:flush(); progress:set(key, total, 900)
+    local okw, errw = f:write(res.body)
+    if not okw then
+      ngx.log(ngx.ERR,"[streamcache] write failed: ", tostring(errw), " rid=", RID)
+      f:close(); os.remove(tmp); httpc:close(); inflight:delete(key)
+      return ngx.exit(ngx.HTTP_BAD_GATEWAY)
+    end
+    local okf, errf = pcall(function() return f:flush() end)
+    if not okf then ngx.log(ngx.WARN,"[streamcache] flush failed: ", tostring(errf)) end
+    progress:set(key, total, 900)
+    local exp = totals:get(key); if exp then refresh_totals(key, tonumber(exp)) end
     if client_alive then pcall(ngx.print, res.body); ngx.flush(true) end
   end
+  if client_alive then ngx.flush(true) end
 
-  f:flush(); progress:set(key, total, 900); f:close(); httpc:close()
+  local okf2, errf2 = pcall(function() return f:flush() end)
+  if not okf2 then ngx.log(ngx.WARN,"[streamcache] flush failed: ", tostring(errf2)) end
+  progress:set(key, total, 900)
+  local exp2 = totals:get(key); if exp2 then refresh_totals(key, tonumber(exp2)) end
+  f:close(); httpc:close()
 
-  if total > 0 then
-    os.rename(tmp, dest_path)
-    local ts = ngx.now(); write_meta(key, total, ts); access:set(key, ts)
-    if VERBOSE then ngx.log(ngx.NOTICE,"[streamcache] tee complete key=", key, " size=", b2human(total)) end
+  -- Strict commit: only if expected size is known and fully matched
+  local expected = tonumber(totals:get(key) or 0)
+  if expected > 0 then
+    if total == expected then
+      local okr, errr = os.rename(tmp, dest_path)
+      if not okr then
+        ngx.log(ngx.ERR,"[streamcache] commit rename failed: ", tostring(errr),
+        " tmp=", tmp, " dest=", dest_path, " rid=", RID)
+        -- Best-effort copy fallback then remove tmp
+        local src = io.open(tmp, "rb"); local dst = io.open(dest_path, "wb")
+        if src and dst then
+          local buf = src:read("*a"); if buf then dst:write(buf) end
+          dst:close(); src:close(); os.remove(tmp)
+        end
+      end
+      local ts = ngx.now(); write_meta(key, total, ts); access:set(key, ts)
+      jlog(ngx.NOTICE, "tee_complete", {size=b2human(total), expected=expected})
+    else
+      os.remove(tmp)
+      ngx.log(ngx.WARN,"[streamcache] not committing (truncated): written=", tostring(total),
+      " expected=", tostring(expected), " key=", key)
+    end
   else
-    os.remove(tmp); ngx.log(ngx.WARN,"[streamcache] tee produced 0 bytes; not committing key=", key)
+    -- Unknown expected size => do not commit to cache
+    if total > 0 then
+      os.remove(tmp)
+      ngx.log(ngx.WARN,"[streamcache] not committing (unknown total size); key=", key, " written=", tostring(total))
+    else
+      os.remove(tmp); ngx.log(ngx.WARN,"[streamcache] tee produced 0 bytes; not committing key=", key)
+    end
   end
-
   inflight:delete(key)
   return
 end
 
--- Tee with near-start window: fetch 0-; cache full; serve client slice only
-local function tee_stream_range_window(final_url, dest_path, key, client_start, client_end, orig_url_for_ref)
+-- Tee with near-start window: fetch 0-; cache full; serve client slice only (strict commit)
+-- (now also supports send_to_client=false, though we do not use it for writer)
+local function tee_stream_range_window(final_url, dest_path, key, client_start, client_end, orig_url_for_ref, send_to_client)
+  if send_to_client == nil then send_to_client = true end
+  set_var_safe("sc_decision", "MISS_TEE_WINDOW")
   final_url = (final_url or ""):gsub("^%s+", ""):gsub("[%s\r\n]+$", "")
   local scheme, host, port, path, host_header = parse_url(final_url)
   if not scheme then ngx.log(ngx.WARN,"[streamcache] tee-window parse failed url=",tostring(final_url)); inflight:delete(key); return ngx.exit(ngx.HTTP_BAD_GATEWAY) end
@@ -436,6 +575,7 @@ local function tee_stream_range_window(final_url, dest_path, key, client_start, 
     end
     return true
   end
+
   if not connect_to(host, port, scheme) then httpc:close(); inflight:delete(key); return ngx.exit(ngx.HTTP_BAD_GATEWAY) end
 
   local ch = ngx.req.get_headers()
@@ -482,13 +622,13 @@ local function tee_stream_range_window(final_url, dest_path, key, client_start, 
   local headers_l = {}; for k,v in pairs(res.headers or {}) do headers_l[string.lower(k)] = v end
   local total_size = nil
   if headers_l["content-range"] then
-    local s0,e0,t0 = headers_l["content-range"]:match("^bytes%s+(%d+)%-(%d+)%/(%d+)$")
+    local s0,e0,t0 = headers_l["content-range"]:match("^bytes%s+(%d+)%-(%d+)/(%d+)$")
     if s0 and tonumber(s0) == 0 and e0 and t0 then total_size = tonumber(t0) end
   end
   if not total_size and headers_l["content-length"] and res.status == 200 then
     total_size = tonumber(headers_l["content-length"])
   end
-  if total_size and total_size > 0 then totals:set(key, total_size, 900) end
+  if total_size and total_size > 0 then refresh_totals(key, total_size) end
 
   if not total_size or total_size <= 0 then
     httpc:close(); inflight:delete(key)
@@ -506,24 +646,27 @@ local function tee_stream_range_window(final_url, dest_path, key, client_start, 
   end
   local send_len = (send_end - send_start + 1)
 
-  -- Prepare 206 headers to client
-  local hcopy = {}
-  for k,v in pairs(res.headers or {}) do
-    local kl = string.lower(k)
-    if kl == "content-type" or kl == "etag" or kl == "last-modified" or kl == "content-disposition" then
-      hcopy[k] = v
+  if send_to_client then
+    -- Prepare 206 headers to client
+    local hcopy = {}
+    for k,v in pairs(res.headers or {}) do
+      local kl = string.lower(k)
+      if kl == "content-type" or kl == "etag" or kl == "last-modified" or kl == "content-disposition" then
+        hcopy[k] = v
+      end
     end
+    hcopy["Accept-Ranges"] = "bytes"
+    hcopy["Content-Range"] = string.format("bytes %d-%d/%d", send_start, send_end, total_size)
+    hcopy["Content-Length"] = tostring(send_len)
+    ngx.status = ngx.HTTP_PARTIAL_CONTENT
+    for k,v in pairs(hcopy) do ngx.header[k] = v end
+    ngx.send_headers()
   end
-  hcopy["Accept-Ranges"] = "bytes"
-  hcopy["Content-Range"] = string.format("bytes %d-%d/%d", send_start, send_end, total_size)
-  hcopy["Content-Length"] = tostring(send_len)
-  ngx.status = ngx.HTTP_PARTIAL_CONTENT
-  for k,v in pairs(hcopy) do ngx.header[k] = v end
-  ngx.send_headers()
 
   -- Open temp & stream windowed slice while caching full body (with no-cache fallback)
   os.execute("mkdir -p /var/cache/streamcache/tmp")
   local tmp = "/var/cache/streamcache/tmp/" .. key .. ".part"
+  os.remove(tmp)
   local f = io.open(tmp, "wb")
   if not f then
     ngx.log(ngx.ERR,"[streamcache] tee-window cannot open temp: ", tmp, " ; falling back to streaming without cache")
@@ -535,22 +678,29 @@ local function tee_stream_range_window(final_url, dest_path, key, client_start, 
       local from = math.max(send_start - chunk_start, 0) + 1
       local to   = math.min(send_end - chunk_start + 1, chunk_len)
       local slice = chunk:sub(from, to)
-      if #slice > 0 then local okp = pcall(ngx.print, slice); if okp then ngx.flush(true) end end
+      if send_to_client and #slice > 0 then pcall(ngx.print, slice) end -- batched below
       return #slice
     end
+    local flushed_nc = 0
     if res.body_reader then
       while true do
         local chunk, cerr = res.body_reader(32768)
         if cerr then ngx.log(ngx.WARN,"[streamcache] read error (window nocache fallback): ", tostring(cerr)); httpc:close(); inflight:delete(key); return ngx.exit(ngx.HTTP_BAD_GATEWAY) end
         if not chunk then break end
         maybe_send_slice(chunk, pos)
-        pos  = pos + #chunk
+        pos = pos + #chunk
+        if send_to_client then
+          flushed_nc = flushed_nc + #chunk
+          if flushed_nc >= CLIENT_FLUSH_BYTES then ngx.flush(true); flushed_nc = 0 end
+        end
       end
     elseif res.body then
-      maybe_send_slice(res.body, pos)
+      maybe_send_slice(res.body, pos); if send_to_client then ngx.flush(true) end
     end
+    if send_to_client then ngx.flush(true) end
     httpc:close(); inflight:delete(key); return
   end
+
   local total_written, last_report, sent, pos = 0, 0, 0, 0
   local function maybe_send_slice(chunk, chunk_start)
     local chunk_len = #chunk
@@ -559,38 +709,90 @@ local function tee_stream_range_window(final_url, dest_path, key, client_start, 
     local from = math.max(send_start - chunk_start, 0) + 1
     local to   = math.min(send_end - chunk_start + 1, chunk_len)
     local slice = chunk:sub(from, to)
-    if #slice > 0 then local okp = pcall(ngx.print, slice); if okp then ngx.flush(true) end end
+    if send_to_client and #slice > 0 then pcall(ngx.print, slice) end -- no per-slice flush; batched below
     return #slice
   end
+
+  local flushed2 = 0
   if res.body_reader then
     while true do
       local chunk, cerr = res.body_reader(32768)
       if cerr then ngx.log(ngx.WARN,"[streamcache] tee-window read error: ",tostring(cerr)); f:close(); os.remove(tmp); httpc:close(); inflight:delete(key); return ngx.exit(ngx.HTTP_BAD_GATEWAY) end
       if not chunk then break end
       total_written = total_written + #chunk
-      f:write(chunk)
+      local okw, errw = f:write(chunk)
+      if not okw then
+        ngx.log(ngx.ERR,"[streamcache] write failed: ", tostring(errw), " rid=", RID)
+        f:close(); os.remove(tmp); httpc:close(); inflight:delete(key)
+        return ngx.exit(ngx.HTTP_BAD_GATEWAY)
+      end
       if (total_written - last_report) >= PROGRESS_FLUSH_BYTES then
-        f:flush(); progress:set(key, total_written, 900); last_report = total_written
+        local okf, errf = pcall(function() return f:flush() end)
+        if not okf then ngx.log(ngx.WARN,"[streamcache] flush failed: ", tostring(errf)) end
+        progress:set(key, total_written, 900); last_report = total_written
+        local exp = totals:get(key); if exp then refresh_totals(key, tonumber(exp)) end
       end
       sent = sent + maybe_send_slice(chunk, pos)
-      pos  = pos + #chunk
+      pos  = pos  + #chunk
+
+      if send_to_client then
+        flushed2 = flushed2 + #chunk
+        if flushed2 >= CLIENT_FLUSH_BYTES then ngx.flush(true); flushed2 = 0 end
+      end
     end
   elseif res.body then
     local chunk = res.body
     total_written = #chunk
-    f:write(chunk); f:flush(); progress:set(key, total_written, 900)
+    local okw, errw = f:write(chunk)
+    if not okw then
+      ngx.log(ngx.ERR,"[streamcache] write failed: ", tostring(errw), " rid=", RID)
+      f:close(); os.remove(tmp); httpc:close(); inflight:delete(key)
+      return ngx.exit(ngx.HTTP_BAD_GATEWAY)
+    end
+    local okf, errf = pcall(function() return f:flush() end)
+    if not okf then ngx.log(ngx.WARN,"[streamcache] flush failed: ", tostring(errf)) end
+    progress:set(key, total_written, 900)
+    local exp = totals:get(key); if exp then refresh_totals(key, tonumber(exp)) end
     sent = sent + maybe_send_slice(chunk, pos)
-    pos  = pos + #chunk
+    pos  = pos  + #chunk
   end
+  if send_to_client then ngx.flush(true) end
 
-  f:flush(); progress:set(key, total_written, 900); f:close(); httpc:close()
+  local okf2, errf2 = pcall(function() return f:flush() end)
+  if not okf2 then ngx.log(ngx.WARN,"[streamcache] flush failed: ", tostring(errf2)) end
+  progress:set(key, total_written, 900)
+  local exp2 = totals:get(key); if exp2 then refresh_totals(key, tonumber(exp2)) end
+  f:close(); httpc:close()
 
-  if total_written > 0 then
-    os.rename(tmp, dest_path)
+  -- Commit strictly only if complete
+  local expected = tonumber(totals:get(key) or 0)
+  if expected > 0 and total_written == expected then
+    local okr, errr = os.rename(tmp, dest_path)
+    if not okr then
+      ngx.log(ngx.ERR,"[streamcache] commit rename failed: ", tostring(errr),
+      " tmp=", tmp, " dest=", dest_path, " rid=", RID)
+      local src = io.open(tmp, "rb"); local dst = io.open(dest_path, "wb")
+      if src and dst then
+        local buf = src:read("*a"); if buf then dst:write(buf) end
+        dst:close(); src:close(); os.remove(tmp)
+      end
+    end
     local ts = ngx.now(); write_meta(key, total_written, ts); access:set(key, ts)
-    if VERBOSE then ngx.log(ngx.NOTICE,"[streamcache] tee-window complete key=", key, " size=", b2human(total_written), " served=", tostring(sent), "B range=", tostring(send_start), "-", tostring(send_end)) end
+    jlog(ngx.NOTICE, "tee_window_complete", {
+      size=b2human(total_written),
+      served=tostring(sent),
+      start=tostring(send_start),
+      stop=tostring(send_end)
+    })
   else
-    os.remove(tmp); ngx.log(ngx.WARN,"[streamcache] tee-window produced 0 bytes; not committing key=", key)
+    os.remove(tmp)
+    if expected > 0 then
+      ngx.log(ngx.WARN,"[streamcache] not committing (truncated): written=", tostring(total_written),
+      " expected=", tostring(expected), " key=", key)
+    else
+      ngx.log(ngx.WARN,"[streamcache] not committing (unknown total size); key=", key,
+      " written=", tostring(total_written))
+    end
   end
 
   inflight:delete(key)
@@ -601,20 +803,18 @@ end
 local function serve_from_part(final_url, key, req_start, req_end)
   local files_dir = "/var/cache/streamcache/files"
   local tmp = "/var/cache/streamcache/tmp/" .. key .. ".part"
-
   if file_exists(files_dir .. "/" .. key) then
     ngx.header["X-Cache"] = "HIT"
+    set_var_safe("sc_decision", "HIT")
     return ngx.exec("/cache/" .. key)
   end
   local f = io.open(tmp, "rb")
   if not f then return nil, "no_part" end
-
   local total_size = totals:get(key)
   local waited = 0
   while not total_size and waited < 2000 do ngx.sleep(0.05); waited = waited + 50; total_size = totals:get(key) end
   if not total_size then f:close(); return nil, "no_total" end
   total_size = tonumber(total_size)
-
   local start = tonumber(req_start) or 0
   local stop  = (req_end and req_end ~= "") and tonumber(req_end) or (total_size - 1)
   if stop > (total_size - 1) then stop = total_size - 1 end
@@ -622,23 +822,22 @@ local function serve_from_part(final_url, key, req_start, req_end)
     f:close(); ngx.header["Content-Range"] = string.format("bytes */%d", total_size)
     return ngx.exit(ngx.HTTP_REQUESTED_RANGE_NOT_SATISFIABLE)
   end
-
   local oh = fetch_origin_headers(final_url, build_client_like_headers(nil, final_url))
   ngx.status = ngx.HTTP_PARTIAL_CONTENT
   ngx.header["X-Cache"] = "FOLLOW"
-  ngx.header["Accept-Ranges"] = "bytes"
-  ngx.header["Content-Range"] = string.format("bytes %d-%d/%d", start, stop, total_size)
+  set_var_safe("sc_decision", "FOLLOW")
+  ngx.header["Accept-Ranges"]  = "bytes"
+  ngx.header["Content-Range"]  = string.format("bytes %d-%d/%d", start, stop, total_size)
   ngx.header["Content-Length"] = tostring(stop - start + 1)
   if oh["content-type"]        then ngx.header["Content-Type"]        = oh["content-type"] end
-  if oh["etag"]                then ngx.header["ETag"]                = oh["etag"] end
-  if oh["last-modified"]       then ngx.header["Last-Modified"]       = oh["last-modified"] end
-  if oh["content-disposition"] then ngx.header["Content-Disposition"] = oh["content-disposition"] end
+  if oh["etag"]                then ngx.header["ETag"]               = oh["etag"]          end
+  if oh["last-modified"]       then ngx.header["Last-Modified"]      = oh["last-modified"] end
+  if oh["content-disposition"] then ngx.header["Content-Disposition"]= oh["content-disposition"] end
   ngx.send_headers()
 
   local deadline = ngx.now() + FOLLOWER_WAIT_MAX
   local sent, needed, current_offset = 0, (stop - start + 1), start
   f:seek("set", start)
-
   local function available_bytes()
     local p = progress:get(key) or 0
     local avail = p - current_offset
@@ -672,12 +871,29 @@ local function serve_from_part(final_url, key, req_start, req_end)
   return
 end
 
+-- Helper: brief wait-and-follow to avoid duplicate no-cache origin pulls
+local function try_follow_with_wait(orig, key, req_start, req_end)
+  local deadline = ngx.now() + (FOLLOWER_START_WAIT_MS / 1000)
+  while true do
+    local err = serve_from_part(orig, key, req_start, req_end)
+    if not err then return true end                         -- follow succeeded
+    if ngx.now() >= deadline then return false, err end     -- give up after short wait
+    if err ~= "no_part" and err ~= "no_total" then          -- non-retryable reason
+      return false, err
+    end
+    ngx.sleep(0.05)
+  end
+end
+
 -- ===================== Entry (HEAD-safe + policy) =====================
 
 -- Decode Base64URL
-local b64 = ngx.var.b64
+local b64  = ngx.var.b64
 local orig = b64 and b64url_decode(b64) or nil
-if not orig or not orig:match("^https?://") then ngx.log(ngx.WARN,"[streamcache] bad request (invalid or non-http URL)"); return ngx.exit(ngx.HTTP_BAD_REQUEST) end
+if not orig or not orig:match("^https?://") then
+  ngx.log(ngx.WARN,"[streamcache] bad request (invalid or non-http URL)")
+  return ngx.exit(ngx.HTTP_BAD_REQUEST)
+end
 orig = orig:gsub("^%s+",""):gsub("[%s\r\n]+$","")
 
 -- Optional SSRF allowlist
@@ -687,6 +903,7 @@ if allowed and allowed ~= "" then
   local ok=false; for h in allowed:gmatch("[^,%s]+") do if host==h then ok=true; break end end
   if not ok then ngx.status=ngx.HTTP_FORBIDDEN; ngx.say("Host not allowed"); return end
 end
+
 local method = ngx.req.get_method()
 if method ~= "GET" then
   -- HEAD/OPTIONS/etc: no tee, no inflight; never expose 30x
@@ -695,7 +912,7 @@ end
 
 local files_dir = "/var/cache/streamcache/files"
 os.execute("mkdir -p " .. files_dir .. " /var/cache/streamcache/tmp /var/cache/streamcache/meta")
-local key = key_from_url(orig)
+local key        = key_from_url(orig)
 local final_path = files_dir .. "/" .. key
 
 local function update_last_access()
@@ -710,15 +927,16 @@ if file_exists(final_path) then
   else
     ngx.header["X-Cache"] = "HIT"
     if VERBOSE then ngx.log(ngx.INFO,"[streamcache] HIT key=", key, " size=", b2human(sz)) end
+    ngx.var.sc_decision = "HIT"
     update_last_access()
     return ngx.exec("/cache/" .. key)
   end
 end
+
 -- Decide path based on client Range
-local req_range = ngx.req.get_headers()["Range"]
+local req_range   = ngx.req.get_headers()["Range"]
 local use_range_0 = false
 local near_start, near_end = nil, nil
-
 if not req_range or req_range == "" then
   -- No Range from client: behave like a player upstream (Range:0-), normalize to 200 for client
   use_range_0 = true
@@ -733,6 +951,7 @@ else
       use_range_0 = true
     else
       -- Far-seek: stream without cache; follow redirects; never expose Location
+      ngx.var.sc_decision = "MISS_NO_CACHE"
       return stream_no_cache(orig, false)
     end
   else
@@ -740,25 +959,68 @@ else
     use_range_0 = true
   end
 end
+
 -- Only one writer per key
 local added = inflight:add(key, true, 900)
 if not added then
-  -- Writer exists; attempt follower if client requested a range slice
+  -- Writer exists. Prefer to FOLLOW from .part for near-start or no-range
+  local s, e = nil, nil
   if req_range and req_range ~= "" then
-    local s, e = req_range:match("^bytes=(%d+)%-([%d%*]*)$")
-    if s then
-      local err = serve_from_part(orig, key, tonumber(s), (e and e ~= "") and tonumber(e) or nil)
-      if not err then return end
-      if VERBOSE then ngx.log(ngx.INFO,"[streamcache] follow failed: ", tostring(err), " ; fallback nocache key=", key) end
-    end
+    local s1, e1 = req_range:match("^bytes=(%d+)%-([%d%*]*)$")
+    if s1 then s = tonumber(s1); e = (e1 and e1 ~= "") and tonumber(e1) or nil end
+  end
+  if not s then s = 0; e = nil end
+  if s == 0 or s <= RANGE_TEE_THRESHOLD then
+    local ok = try_follow_with_wait(orig, key, s, e)
+    if ok then return end
+    if VERBOSE then ngx.log(ngx.INFO,"[streamcache] follow not ready; fallback nocache key=", key) end
   end
   -- Fallback: stream nocache (never leak redirects)
+  set_var_safe("sc_decision", ((not req_range or req_range == "") and "MISS_NO_CACHE") or "MISS_NO_CACHE")
   return stream_no_cache(orig, (not req_range or req_range == ""))
 end
 
--- Start tee now
-if near_start then
-  return tee_stream_range_window(orig, final_path, key, near_start, near_end, orig)
-else
-  return tee_stream(orig, final_path, key, use_range_0, orig)
+-- We are the first request (writer). Start a background writer-only timer
+local function start_writer_timer(range0)
+  return ngx.timer.at(0, function(premature)
+    if premature then return end
+    -- Writer-only: decoupled from client speed
+    tee_stream(orig, final_path, key, range0, orig, false)
+  end)
 end
+
+local ok_timer, err_timer
+-- For best reuse, prefer writing from the start when feasible
+if near_start then
+  ok_timer, err_timer = start_writer_timer(true)   -- force Range: 0-
+else
+  ok_timer, err_timer = start_writer_timer(use_range_0)
+end
+
+-- If the timer could not be started, fall back to original tee (client-coupled)
+if not ok_timer then
+  if VERBOSE then ngx.log(ngx.WARN, "[streamcache] writer timer failed: ", tostring(err_timer), " ; using inline tee") end
+  if near_start then
+    return tee_stream_range_window(orig, final_path, key, near_start, near_end, orig, true)
+  else
+    return tee_stream(orig, final_path, key, use_range_0, orig, true)
+  end
+end
+
+-- Now follow from the .part for this client
+local follow_start, follow_end = 0, nil
+if req_range and req_range ~= "" then
+  local s2, e2 = req_range:match("^bytes=(%d+)%-([%d%*]*)$")
+  if s2 then
+    follow_start = tonumber(s2) or 0
+    follow_end   = (e2 and e2 ~= "") and tonumber(e2) or nil
+  end
+end
+
+local ok_follow = try_follow_with_wait(orig, key, follow_start, follow_end)
+if ok_follow then
+  return
+end
+
+-- Last-resort fallback (edge): stream nocache
+return stream_no_cache(orig, (not req_range or req_range == ""))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,10 @@ services:
       LOG_VERBOSE: "1"                           # <-- set to "0" to reduce log noise
       RESOLVE_TTL: "600"                         # defaults to 60 sec if not defined, how long proxy will wait before re-resolving CDN location
       TOTALS_TTL_SECS: "14400"                   # default 4h download total TTL
+    #deploy:
+    #  resources:
+    #    limits:
+    #      memory: 12g                            # limit container ram consumption, beware, this includes container file page cache, in-progress downloads count against RAM
     volumes:
       - ./conf/nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf:ro
       - ./conf/streamcache.conf:/etc/openresty/conf.d/streamcache.conf:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,17 +8,20 @@ services:
       - "8080:8080"
     restart: unless-stopped
     environment:
-      CACHE_MAX_BYTES: "536870912000"        # 500 GB
+      CACHE_MAX_BYTES: "536870912000"            # 500 GB
       CACHE_LOW_WATERMARK_BYTES: "531801402880"  # 495 GB
-      RANGE_TEE_THRESHOLD: "20971520"   # 20 MiB near-start window (VLC jumps to like 4MB by default)
-      PROGRESS_FLUSH_BYTES: "262144"   # writer flush/report cadence
-      FOLLOWER_WAIT_MAX: "60"          # seconds the follower will wait for bytes
-      FOLLOWER_POLL_MS: "50"           # follower poll interval (ms)
+      RANGE_TEE_THRESHOLD: "41943040"            # 40 MiB near-start window (VLC jumps to like 4MB by default)
+      PROGRESS_FLUSH_BYTES: "5242880"            # 5 MiB writer flush/report cadence
+      CLIENT_FLUSH_BYTES: "5242880"              # 5 MiB client buffer flush cadence
+      FOLLOWER_START_WAIT_MS: "1500"             # 1.5 sec backoff if cache file doesn't exist when first attempting to service client (copilot recommends 500-1500)
+      FOLLOWER_WAIT_MAX: "60"                    # seconds the follower will wait for bytes
+      FOLLOWER_POLL_MS: "50"                     # follower poll interval (ms)
       CACHE_JANITOR_INTERVAL: "300"
       ALLOWED_HOSTS: ""
       DISABLE_SSL_VERIFY: "0"
-      LOG_VERBOSE: "1"                       # <-- set to "0" to reduce log noise
-      RESOLVE_TTL: "600"                #defaults to 60 sec if not defined, how long proxy will wait before re-resolving CDN location
+      LOG_VERBOSE: "1"                           # <-- set to "0" to reduce log noise
+      RESOLVE_TTL: "600"                         # defaults to 60 sec if not defined, how long proxy will wait before re-resolving CDN location
+      TOTALS_TTL_SECS: "14400"                   # default 4h download total TTL
     volumes:
       - ./conf/nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf:ro
       - ./conf/streamcache.conf:/etc/openresty/conf.d/streamcache.conf:ro


### PR DESCRIPTION
Fixed a few bugs.

Playback sessions would case the cache to be lazy filled as the player requested new ranges from the server.  Decoupled the reader/writer processes so cache fills are always immediate and full speed.  

There was a global download timer baked into the code which caused downloads that took longer than 15 minutes to be evicted instead of committed to the cache. 

Emby's back to back calls against the proxy would happen so fast that the probe would cause a cache fill request, but the second would flow as no-cache causing 2 provider connections to be consumed.  There is now a configurable backoff delay for requests for a URL that have an active worker that hasn't yet committed data to the cache. 