### PR TITLE
Content length bugfix

### DIFF
--- a/conf/streamcache.lua
+++ b/conf/streamcache.lua
@@ -529,8 +529,6 @@ local function tee_stream(final_url, dest_path, key, use_range_0, orig_url_for_r
       local chunk, cerr = res.body_reader(32768)
       if cerr then ngx.log(ngx.WARN,"[streamcache] tee read error: ",tostring(cerr)); f:close(); return fail_exit(ngx.HTTP_BAD_GATEWAY, httpc, key, tmp, send_to_client) end
       if not chunk then break end
-
-      if not chunk then break end
       total = total + #chunk
       local okw, errw = f:write(chunk)
       if not okw then ngx.log(ngx.ERR,"[streamcache] write failed: ", tostring(errw), " rid=", RID); f:close(); return fail_exit(ngx.HTTP_BAD_GATEWAY, httpc, key, tmp, send_to_client) end

--- a/conf/streamcache.lua
+++ b/conf/streamcache.lua
@@ -516,7 +516,7 @@ local function tee_stream(final_url, dest_path, key, use_range_0, orig_url_for_r
   local f = io.open(tmp, "wb")
   if not f then
     ngx.log(ngx.ERR,"[streamcache] tee cannot open temp: ", tmp, " ; falling back")
-    httpc:close(); inflight:delete(key); return
+    return fail_exit(ngx.HTTP_BAD_GATEWAY, httpc, key, nil, send_to_client)
   end
 
   local total = 0


### PR DESCRIPTION
Add more robust content length checking to attempt to block partial downloads from being committed to cache. 

Implement cleaner exit functionality for calls that happen within timers. 