### PR TITLE
Modular refactor

### DIFF
--- a/conf/lib/sc_config.lua
+++ b/conf/lib/sc_config.lua
@@ -1,0 +1,35 @@
+-- sc_config.lua
+-- Configuration loader from environment variables.
+
+local Config = {}
+
+function Config.load()
+  local os = os
+  local tonumber = tonumber
+
+  local conf = {
+    VERBOSE               = (os.getenv("LOG_VERBOSE") == "1"),
+    RANGE_TEE_THRESHOLD   = tonumber(os.getenv("RANGE_TEE_THRESHOLD")   or "") or (5 * 1024 * 1024),
+    PROGRESS_FLUSH_BYTES  = tonumber(os.getenv("PROGRESS_FLUSH_BYTES")  or "") or 262144,
+    FOLLOWER_WAIT_MAX     = tonumber(os.getenv("FOLLOWER_WAIT_MAX")     or "") or 600,
+    FOLLOWER_POLL_MS      = tonumber(os.getenv("FOLLOWER_POLL_MS")      or "") or 50,
+    FOLLOWER_START_WAIT_MS= tonumber(os.getenv("FOLLOWER_START_WAIT_MS")or "") or 750,
+    FOLLOWER_MIN_BYTES    = tonumber(os.getenv("FOLLOWER_MIN_BYTES")    or "") or 65536,
+    CLIENT_FLUSH_BYTES    = tonumber(os.getenv("CLIENT_FLUSH_BYTES")    or "") or (1 * 1024 * 1024),
+    TOTALS_TTL_SECS       = tonumber(os.getenv("TOTALS_TTL_SECS")       or "") or 86400,
+    SSL_VERIFY            = (os.getenv("DISABLE_SSL_VERIFY") ~= "1"),
+    ALLOWED_HOSTS         = os.getenv("ALLOWED_HOSTS"),
+    CACHE_DIR             = "/var/cache/streamcache/files",
+    TMP_DIR               = "/var/cache/streamcache/tmp",
+    META_DIR              = "/var/cache/streamcache/meta",
+    -- Inflight TTL: how long the writer lock lasts before expiry (seconds).
+    -- Must exceed the longest expected download time.
+    INFLIGHT_TTL          = 900,
+    -- Fadvise threshold: writer drops page cache pages every N bytes.
+    -- Smaller = less dirty page accumulation but more syscalls.
+    FADVISE_CHUNK         = 2 * 1024 * 1024,
+  }
+  return conf
+end
+
+return Config

--- a/conf/lib/sc_file.lua
+++ b/conf/lib/sc_file.lua
@@ -1,0 +1,241 @@
+-- sc_file.lua
+-- File operations with LuaJIT FFI for posix_fadvise support.
+-- Handles cache file creation, commit, and page-cache management.
+--
+-- Page cache strategy:
+--   Writer: write() → sync_file_range(WRITE) → fadvise(DONTNEED)
+--     fadvise only drops CLEAN pages; dirty pages are ignored. We must
+--     flush dirty pages to disk first via sync_file_range, then drop.
+--   Follower: read via FFI fd → fadvise(DONTNEED) on read data
+--     Prevents follower reads from re-caching pages the writer dropped.
+
+local ngx = ngx
+local os  = os
+local io  = io
+local ffi = require "ffi"
+local bit = require "bit"
+
+ffi.cdef[[
+  int open(const char *pathname, int flags, int mode);
+  long read(int fd, void *buf, unsigned long count);
+  long write(int fd, const void *buf, unsigned long count);
+  int close(int fd);
+  int fsync(int fd);
+  long lseek(int fd, long offset, int whence);
+  int posix_fadvise(int fd, long offset, long len, int advice);
+  int sync_file_range(int fd, long offset, long nbytes, unsigned int flags);
+  char *strerror(int errnum);
+]]
+
+-- Linux x86_64 constants
+local O_RDONLY = 0
+local O_WRONLY = 1
+local O_CREAT  = 64
+local O_TRUNC  = 512
+local O_WRITE_FLAGS = bit.bor(O_WRONLY, O_CREAT, O_TRUNC)
+
+local S_IRUSR  = 256
+local S_IWUSR  = 128
+local S_IRGRP  = 32
+local S_IROTH  = 4
+local S_MODE   = bit.bor(S_IRUSR, S_IWUSR, S_IRGRP, S_IROTH) -- 0644
+
+local SEEK_SET = 0
+
+local POSIX_FADV_DONTNEED = 4
+
+-- sync_file_range flags
+local SYNC_FILE_RANGE_WAIT_BEFORE = 1
+local SYNC_FILE_RANGE_WRITE       = 2
+
+local File = {}
+
+function File.exists(path)
+  local f = io.open(path, "rb")
+  if f then f:close(); return true end
+  return false
+end
+
+function File.size(path)
+  local f = io.open(path, "rb")
+  if not f then return 0 end
+  local sz = f:seek("end")
+  f:close()
+  return sz or 0
+end
+
+function File.remove(path)
+  if path and path ~= "" then
+    pcall(os.remove, path)
+  end
+end
+
+-- Write cache metadata (size + last-access timestamp).
+-- Uses standard io for small files; safe in any context.
+function File.write_meta(key, size, last, meta_dir)
+  meta_dir = meta_dir or "/var/cache/streamcache/meta"
+  local f = io.open(meta_dir .. "/" .. key .. ".meta", "wb")
+  if not f then return end
+  f:write("size=" .. tostring(size or 0) .. "\n")
+  f:write("last_access=" .. tostring(last or ngx.now()) .. "\n")
+  f:close()
+end
+
+-- Create directories. Accepts a table of paths or a single string.
+function File.ensure_dirs(dirs)
+  if type(dirs) == "table" then
+    for _, d in ipairs(dirs) do
+      os.execute("mkdir -p " .. d)
+    end
+  else
+    os.execute("mkdir -p " .. tostring(dirs))
+  end
+end
+
+-- Rename with chunked copy fallback + post-commit size verification.
+function File.rename(src, dest, expected_size)
+  local ok, err = os.rename(src, dest)
+  if ok then
+    if expected_size and expected_size > 0 then
+      local actual = File.size(dest)
+      if actual ~= expected_size then
+        ngx.log(ngx.ERR, "[streamcache] post-rename size mismatch: expected=",
+          tostring(expected_size), " actual=", tostring(actual))
+        File.remove(dest)
+        return false, "post_rename_size_mismatch"
+      end
+    end
+    return true
+  end
+
+  -- Cross-filesystem fallback: chunked copy (1MB chunks)
+  local src_f = io.open(src, "rb")
+  local dst_f = io.open(dest, "wb")
+  if not src_f or not dst_f then
+    if src_f then src_f:close() end
+    if dst_f then dst_f:close() end
+    return false, err
+  end
+
+  local CHUNK_SZ = 1024 * 1024
+  local copied = 0
+  while true do
+    local chunk = src_f:read(CHUNK_SZ)
+    if not chunk then break end
+    local wok, werr = dst_f:write(chunk)
+    if not wok then
+      dst_f:close(); src_f:close()
+      File.remove(dest)
+      return false, "copy_write_failed: " .. tostring(werr)
+    end
+    copied = copied + #chunk
+  end
+  dst_f:close()
+  src_f:close()
+
+  if expected_size and expected_size > 0 and copied ~= expected_size then
+    ngx.log(ngx.ERR, "[streamcache] post-copy size mismatch: expected=",
+      tostring(expected_size), " copied=", tostring(copied))
+    File.remove(dest)
+    return false, "post_copy_size_mismatch"
+  end
+
+  File.remove(src)
+  return true
+end
+
+-- ======================== FFI: Write Operations ========================
+
+function File.open_fd(path)
+  local fd = ffi.C.open(path, O_WRITE_FLAGS, S_MODE)
+  if fd < 0 then return nil, "open_error" end
+  return fd
+end
+
+function File.write_fd(fd, data)
+  local len = #data
+  local written = 0
+  local ptr = ffi.cast("const char*", data)
+  while written < len do
+    local res = ffi.C.write(fd, ptr + written, len - written)
+    if res < 0 then return nil, "write_error" end
+    written = written + tonumber(res)
+  end
+  return written
+end
+
+function File.close_fd(fd)
+  if fd and fd >= 0 then ffi.C.close(fd) end
+end
+
+function File.fsync_fd(fd)
+  if fd and fd >= 0 then ffi.C.fsync(fd) end
+end
+
+-- ======================== FFI: Read Operations (for follower) ========================
+
+-- Reusable read buffer (avoids per-call allocation)
+local READ_BUF_SIZE = 65536
+local read_buf = ffi.new("char[?]", READ_BUF_SIZE)
+
+function File.open_read_fd(path)
+  local fd = ffi.C.open(path, O_RDONLY, 0)
+  if fd < 0 then return nil, "open_error" end
+  return fd
+end
+
+function File.seek_fd(fd, offset)
+  if fd and fd >= 0 then
+    local pos = ffi.C.lseek(fd, offset, SEEK_SET)
+    return tonumber(pos)
+  end
+  return -1
+end
+
+function File.read_fd(fd, size)
+  if not fd or fd < 0 then return nil end
+  if size > READ_BUF_SIZE then size = READ_BUF_SIZE end
+  local n = ffi.C.read(fd, read_buf, size)
+  if n <= 0 then return nil end
+  return ffi.string(read_buf, n)
+end
+
+-- ======================== Page Cache Management ========================
+
+-- Initiate async writeback of dirty pages in the given range.
+-- This does NOT block — it starts I/O and returns immediately.
+-- Call drop_cache() on a PREVIOUS range after this to drop clean pages.
+function File.start_writeback(fd, offset, len)
+  if fd and fd >= 0 and len > 0 then
+    ffi.C.sync_file_range(fd, offset, len, SYNC_FILE_RANGE_WRITE)
+  end
+end
+
+-- Wait for pages in range to be clean, then tell kernel to drop them.
+-- The two-step (sync_file_range + fadvise) is required because
+-- fadvise(DONTNEED) silently ignores dirty pages.
+function File.drop_cache(fd, offset, len)
+  if fd and fd >= 0 and len > 0 then
+    -- Wait for any in-progress writeback to complete
+    ffi.C.sync_file_range(fd, offset, len,
+      bit.bor(SYNC_FILE_RANGE_WAIT_BEFORE, SYNC_FILE_RANGE_WRITE))
+    -- Now pages are clean; drop them from cache
+    ffi.C.posix_fadvise(fd, offset, len, POSIX_FADV_DONTNEED)
+  end
+end
+
+-- Drop clean (read-only) pages from cache. No sync_file_range needed
+-- because the reader never dirties pages. Cheaper than drop_cache().
+-- Used by the follower which only reads from .part files.
+function File.drop_read_cache(fd, offset, len)
+  if fd and fd >= 0 and len > 0 then
+    ffi.C.posix_fadvise(fd, offset, len, POSIX_FADV_DONTNEED)
+  end
+end
+
+-- Legacy alias (used in final-fadvise paths)
+function File.fadvise(fd, offset, len)
+  File.drop_cache(fd, offset, len)
+end
+
+return File

--- a/conf/lib/sc_follower.lua
+++ b/conf/lib/sc_follower.lua
@@ -1,0 +1,203 @@
+-- sc_follower.lua
+-- Follower logic: serves a client from a growing .part file written
+-- by the tee writer.
+--
+-- IMPROVEMENTS over production:
+--   - Reads cached origin headers from `resolved` shared dict (no extra HEAD)
+--   - Reads .part via FFI fd + fadvise(DONTNEED) to prevent re-caching
+--     pages the writer already dropped from page cache
+
+local ngx      = ngx
+local math     = math
+local Utils    = require "sc_utils"
+local File     = require "sc_file"
+local Upstream = require "sc_upstream"
+
+local Follower = {}
+
+-- Read cached origin headers from the resolved shared dict.
+-- Returns: content_type, etag, last_modified, content_disposition (all may be nil)
+local function get_cached_headers(resolved, key)
+  if not resolved then return nil end
+  local hdr_str = resolved:get("hdr:" .. key)
+  if not hdr_str then return nil end
+  local ct, et, lm, cd = hdr_str:match("^(.-)\n(.-)\n(.-)\n(.*)$")
+  if ct == "" then ct = nil end
+  if et == "" then et = nil end
+  if lm == "" then lm = nil end
+  if cd == "" then cd = nil end
+  return ct, et, lm, cd
+end
+
+-- Serve bytes from a growing .part file (or completed cache file).
+-- Returns: true (success), or nil + error string
+function Follower.serve(ctx, final_url, req_start, req_end)
+  local key      = ctx.key
+  local cfg      = ctx.config
+  local progress = ctx.shared.progress
+  local totals   = ctx.shared.totals
+  local resolved = ctx.shared.resolved
+
+  local final_path = cfg.CACHE_DIR .. "/" .. key
+
+  -- Fast check: did it finish while we were waiting?
+  if File.exists(final_path) then
+    ngx.header["X-Cache"] = "HIT"
+    Utils.set_var_safe("sc_decision", "HIT")
+    return ngx.exec("/cache/" .. key)
+  end
+
+  -- Open .part via FFI (gives us fd for fadvise after reads)
+  local tmp = cfg.TMP_DIR .. "/" .. key .. ".part"
+  local fd = File.open_read_fd(tmp)
+  if not fd then return nil, "no_part" end
+
+  -- Wait for total size to become available (writer sets it early)
+  local total_size = totals:get(key)
+  local waited = 0
+  while not total_size and waited < 2000 do
+    ngx.sleep(0.05)
+    waited = waited + 50
+    total_size = totals:get(key)
+  end
+  if not total_size then File.close_fd(fd); return nil, "no_total" end
+  total_size = tonumber(total_size)
+
+  -- Compute range bounds
+  local start = tonumber(req_start) or 0
+  local stop  = (req_end and req_end ~= "") and tonumber(req_end) or (total_size - 1)
+  if stop > (total_size - 1) then stop = total_size - 1 end
+  if start > stop or start > total_size - 1 then
+    File.close_fd(fd)
+    ngx.header["Content-Range"] = string.format("bytes */%d", total_size)
+    return ngx.exit(ngx.HTTP_REQUESTED_RANGE_NOT_SATISFIABLE)
+  end
+
+  -- Get origin headers: try cached first, fall back to HEAD probe
+  local ct, et, lm, cd = get_cached_headers(resolved, key)
+  if not ct then
+    local oh = Upstream.fetch_origin_headers(final_url,
+      Upstream.build_client_like_headers(nil, final_url), cfg.SSL_VERIFY)
+    ct = oh["content-type"]
+    et = oh["etag"]
+    lm = oh["last-modified"]
+    cd = oh["content-disposition"]
+  end
+
+  -- Determine whether client actually sent a Range header.
+  -- If not, respond with 200 OK (not 206) to satisfy browsers like Chrome.
+  local client_range = ngx.req.get_headers()["Range"]
+  local client_sent_range = (client_range ~= nil and client_range ~= "")
+
+  ngx.header["X-Cache"]       = "FOLLOW"
+  Utils.set_var_safe("sc_decision", "FOLLOW")
+  ngx.header["Accept-Ranges"] = "bytes"
+  if ct then ngx.header["Content-Type"]        = ct end
+  if et then ngx.header["ETag"]                = et end
+  if lm then ngx.header["Last-Modified"]       = lm end
+  if cd then ngx.header["Content-Disposition"]  = cd end
+
+  if client_sent_range then
+    -- Client asked for a range: send 206 with Content-Range
+    ngx.status = ngx.HTTP_PARTIAL_CONTENT
+    ngx.header["Content-Range"]  = string.format("bytes %d-%d/%d", start, stop, total_size)
+    ngx.header["Content-Length"] = tostring(stop - start + 1)
+  else
+    -- Client sent no Range: send 200 with full Content-Length
+    ngx.status = ngx.HTTP_OK
+    ngx.header["Content-Length"] = tostring(total_size)
+  end
+  ngx.send_headers()
+
+  -- Register abort handler: when the client disconnects, ngx.on_abort
+  -- fires in a separate light thread and sets our flag. This works
+  -- because lua_check_client_abort is on for this location.
+  local aborted = false
+  local ok_abort = pcall(ngx.on_abort, function() aborted = true end)
+
+  -- Streaming loop: read from .part file as writer produces data
+  local deadline = ngx.now() + cfg.FOLLOWER_WAIT_MAX
+  local poll_sec = cfg.FOLLOWER_POLL_MS / 1000
+
+  -- Wait for minimum bytes before starting to stream
+  while (progress:get(key) or 0) < cfg.FOLLOWER_MIN_BYTES
+        and ngx.now() < deadline and not aborted do
+    ngx.sleep(poll_sec)
+  end
+
+  local sent = 0
+  local needed = stop - start + 1
+  local current_offset = start
+  local last_drop = start  -- track fadvise position for read pages
+  local FADVISE_READ_CHUNK = 2 * 1024 * 1024  -- drop read pages every 2MB
+
+  File.seek_fd(fd, start)
+
+  while sent < needed and not aborted do
+    local p = progress:get(key) or 0
+    local avail = p - current_offset
+    if avail < 0 then avail = 0 end
+    local remaining = needed - sent
+    if avail > remaining then avail = remaining end
+
+    if avail > 0 then
+      local chunk_sz = math.min(avail, 8192)
+      local chunk = File.read_fd(fd, chunk_sz)
+      if not chunk then
+        -- File read returned nothing; writer may not have flushed yet
+        ngx.sleep(poll_sec)
+      else
+        -- Send to client; detect disconnect via both print and flush
+        local okp = pcall(ngx.print, chunk)
+        if not okp then break end
+        local okf = pcall(ngx.flush, true)
+        if not okf then break end
+
+        sent = sent + #chunk
+        current_offset = current_offset + #chunk
+
+        -- Drop read pages from cache periodically (read-only: no sync needed)
+        if (current_offset - last_drop) >= FADVISE_READ_CHUNK then
+          File.drop_read_cache(fd, last_drop, current_offset - last_drop)
+          last_drop = current_offset
+        end
+      end
+    else
+      -- No new data available; check abort and deadline
+      if aborted then break end
+      if ngx.now() > deadline then
+        if current_offset > last_drop then
+          File.drop_read_cache(fd, last_drop, current_offset - last_drop)
+        end
+        File.close_fd(fd)
+        ngx.log(ngx.WARN, "[streamcache] follower timeout key=", key,
+          " offset=", tostring(current_offset))
+        return ngx.exit(ngx.HTTP_OK)
+      end
+      ngx.sleep(poll_sec)
+    end
+  end
+
+  -- Cleanup: drop any remaining read pages and close fd
+  if current_offset > last_drop then
+    File.drop_read_cache(fd, last_drop, current_offset - last_drop)
+  end
+  File.close_fd(fd)
+  return true
+end
+
+-- Brief wait-and-follow to avoid duplicate no-cache origin pulls.
+function Follower.try_follow_with_wait(ctx, final_url, start, stop)
+  local cfg = ctx.config
+  local deadline = ngx.now() + (cfg.FOLLOWER_START_WAIT_MS / 1000)
+
+  while true do
+    local ok, err = Follower.serve(ctx, final_url, start, stop)
+    if ok then return true end
+    if ngx.now() >= deadline then return false, err end
+    if err ~= "no_part" and err ~= "no_total" then return false, err end
+    ngx.sleep(0.05)
+  end
+end
+
+return Follower

--- a/conf/lib/sc_nocache.lua
+++ b/conf/lib/sc_nocache.lua
@@ -1,0 +1,129 @@
+-- sc_nocache.lua
+-- No-cache streaming: far-seek passthrough and HEAD handling.
+-- These code paths do NOT write to disk — they stream directly from
+-- upstream to the client, following redirects and masking Location headers.
+
+local ngx      = ngx
+local Utils    = require "sc_utils"
+local Upstream = require "sc_upstream"
+
+local NoCache = {}
+
+-- Stream upstream response to client without caching.
+-- Follows redirects internally (via Upstream.request); never exposes
+-- Location headers to the client.
+--
+-- normalize_200: if true, converts 206→200 when client didn't send Range
+--   (used when the proxy added Range:0- internally)
+function NoCache.stream(url, cfg, client_headers, normalize_200)
+  Utils.set_var_safe("sc_decision",
+    (ngx.var.sc_decision ~= "" and ngx.var.sc_decision) or "MISS_NO_CACHE")
+
+  local ch = client_headers or ngx.req.get_headers()
+  local headers = Upstream.build_client_like_headers(nil, url, ch)
+  headers["Range"] = ch["Range"] or ch["range"]  -- passthrough range as-is
+
+  local res, httpc, _ = Upstream.request(url, {
+    method     = "GET",
+    headers    = headers,
+    ssl_verify = cfg.SSL_VERIFY,
+  })
+  if not res then return ngx.exit(ngx.HTTP_BAD_GATEWAY) end
+
+  -- Parse total size for normalization
+  local hl = {}
+  for k, v in pairs(res.headers or {}) do hl[string.lower(k)] = v end
+  local total_size = nil
+  if hl["content-range"] then
+    local t0 = hl["content-range"]:match("/(%d+)$")
+    if t0 then total_size = tonumber(t0) end
+  end
+  if not total_size and hl["content-length"] and res.status == 200 then
+    total_size = tonumber(hl["content-length"])
+  end
+
+  -- Filter headers (consistent hop-by-hop stripping)
+  local hcopy = Utils.filter_response_headers(res.headers)
+  hcopy["X-Cache"] = "MISS"
+
+  -- Normalize 206→200 when client didn't request a Range
+  local client_sent_range = (ch["Range"] or ch["range"]) ~= nil
+  if normalize_200 and (not client_sent_range) and res.status == 206 then
+    hcopy["Content-Range"] = nil
+    if total_size and total_size > 0 then
+      hcopy["Content-Length"] = tostring(total_size)
+    else
+      hcopy["Content-Length"] = nil
+    end
+    ngx.status = ngx.HTTP_OK
+  else
+    ngx.status = res.status
+  end
+
+  for k, v in pairs(hcopy) do ngx.header[k] = v end
+  ngx.send_headers()
+
+  -- Stream body with batched flushes
+  local flushed = 0
+  if res.body_reader then
+    while true do
+      local chunk, cerr = res.body_reader(32768)
+      if cerr then
+        ngx.log(ngx.WARN, "[streamcache] nocache read error: ", tostring(cerr))
+        httpc:close()
+        return ngx.exit(ngx.HTTP_BAD_GATEWAY)
+      end
+      if not chunk then break end
+      local okp = pcall(ngx.print, chunk)
+      if okp then
+        flushed = flushed + #chunk
+        if flushed >= cfg.CLIENT_FLUSH_BYTES then ngx.flush(true); flushed = 0 end
+      end
+    end
+  elseif res.body then
+    local okp = pcall(ngx.print, res.body)
+    if okp then ngx.flush(true) end
+  end
+
+  ngx.flush(true)
+  httpc:close()
+  return
+end
+
+-- HEAD handler: follow redirects; never expose Location; no body.
+-- Also handles 405 fallback (GET bytes=0-0) for servers that reject HEAD.
+function NoCache.head(url, cfg, client_headers)
+  Utils.set_var_safe("sc_decision", "HEAD_NOCACHE")
+
+  local ch = client_headers or ngx.req.get_headers()
+  local headers = Upstream.build_client_like_headers(nil, url, ch)
+
+  -- Try HEAD first, fall back to GET 0-0
+  local res, httpc, _ = Upstream.request(url, {
+    method     = "HEAD",
+    headers    = headers,
+    ssl_verify = cfg.SSL_VERIFY,
+  })
+  if not res then return ngx.exit(ngx.HTTP_BAD_GATEWAY) end
+
+  if res.status == 405 then
+    httpc:close()
+    headers["Range"] = headers["Range"] or "bytes=0-0"
+    res, httpc, _ = Upstream.request(url, {
+      method     = "GET",
+      headers    = headers,
+      ssl_verify = cfg.SSL_VERIFY,
+    })
+    if not res then return ngx.exit(ngx.HTTP_BAD_GATEWAY) end
+  end
+
+  -- Filter headers
+  local hcopy = Utils.filter_response_headers(res.headers)
+  ngx.status = ngx.HTTP_OK
+  for k, v in pairs(hcopy) do ngx.header[k] = v end
+  ngx.send_headers()
+  httpc:close()
+  return
+end
+
+return NoCache

--- a/conf/lib/sc_tee.lua
+++ b/conf/lib/sc_tee.lua
@@ -1,0 +1,535 @@
+-- sc_tee.lua
+-- Tee streaming: upstream → client + disk (strict commit).
+--
+-- Two modes:
+--   tee_stream:              Full-body tee; optional client serving
+--   tee_stream_range_window: Cache full body; serve client a byte slice
+--
+-- Improvements over production monolith:
+--   • FFI writes with posix_fadvise(FADV_DONTNEED) to prevent OOM
+--   • Inflight TTL refresh during long downloads
+--   • Post-commit size verification
+--   • Chunked copy fallback (no read("*a") OOM)
+--   • Origin headers cached in shared dict for follower use
+--   • Range-hostile fallback (retry without Range on 416/400/403)
+
+local ngx      = ngx
+local math     = math
+local Utils    = require "sc_utils"
+local File     = require "sc_file"
+local Upstream = require "sc_upstream"
+
+local Tee = {}
+
+-- ======================== Internal Helpers ========================
+
+-- Unified cleanup: close connections, remove temp, clear inflight.
+-- Safe in both request and timer contexts.
+local function cleanup_writer(httpc, key, tmp, inflight)
+  pcall(function() if httpc then httpc:close() end end)
+  if tmp and tmp ~= "" then File.remove(tmp) end
+  if key and inflight then inflight:delete(key) end
+end
+
+-- Unified failure: cleanup + exit (request) or return (timer).
+local function fail_exit(code, httpc, key, tmp, inflight, send_to_client)
+  cleanup_writer(httpc, key, tmp, inflight)
+  if send_to_client then
+    return ngx.exit(code)
+  end
+  return
+end
+
+-- Refresh the totals TTL during long downloads.
+local function refresh_totals(totals, key, size, ttl)
+  if not key or not size or size <= 0 then return end
+  totals:set(key, size, ttl)
+end
+
+-- Cache origin response headers in the `resolved` shared dict so
+-- followers can read them without making an extra HEAD request.
+local function cache_origin_headers(resolved, key, response_headers)
+  if not resolved or not response_headers then return end
+  local hl = {}
+  for k, v in pairs(response_headers) do hl[string.lower(k)] = v end
+  -- Store as newline-delimited: content-type\netag\nlast-modified\ncontent-disposition
+  local ct = hl["content-type"] or ""
+  local et = hl["etag"] or ""
+  local lm = hl["last-modified"] or ""
+  local cd = hl["content-disposition"] or ""
+  resolved:set("hdr:" .. key, ct .. "\n" .. et .. "\n" .. lm .. "\n" .. cd, 3600)
+end
+
+-- Parse total size from response headers (Content-Range or Content-Length).
+local function parse_total_size(res)
+  local hl = {}
+  for k, v in pairs(res.headers or {}) do hl[string.lower(k)] = v end
+  local total = nil
+  if hl["content-range"] then
+    local t0 = hl["content-range"]:match("/(%d+)$")
+    if t0 then total = tonumber(t0) end
+  end
+  if not total and hl["content-length"] and res.status == 200 then
+    total = tonumber(hl["content-length"])
+  end
+  return total, hl
+end
+
+-- Try a range-hostile retry: drop Range header, probe size via HEAD first.
+-- Returns new res, httpc or nil.
+local function range_hostile_retry(url, options, totals, key, cfg, orig_url, client_headers)
+  local probe_hdrs = Upstream.build_client_like_headers(nil, orig_url, client_headers)
+  local expected_head, _ = Upstream.probe_total_with_head(url, probe_hdrs, cfg.SSL_VERIFY)
+  if expected_head and expected_head > 0 then
+    totals:set(key, expected_head, cfg.TOTALS_TTL_SECS)
+  else
+    totals:delete(key)
+  end
+  -- Retry without Range
+  local retry_opts = Utils.tclone(options)
+  retry_opts.headers = Utils.tclone(options.headers or {})
+  retry_opts.headers["Range"] = nil
+  return Upstream.request(url, retry_opts)
+end
+
+-- ======================== Streaming Write Loop ========================
+-- Shared by both tee_stream and tee_stream_range_window.
+-- Writes upstream body to an FFI file descriptor while optionally
+-- sending bytes to the client (full body or windowed slice).
+--
+-- Returns: total_written, sent_to_client, error_string
+local function write_loop(ctx, res, httpc, fd, tmp, send_to_client, client_opts)
+  local cfg = ctx.config
+  local key = ctx.key
+  local rid = ctx.rid
+  local progress = ctx.shared.progress
+  local totals   = ctx.shared.totals
+  local inflight = ctx.shared.inflight
+
+  local total_written = 0
+  local last_report   = 0
+  local last_fadvise  = 0
+  local prev_wb_off   = nil  -- previous writeback range offset
+  local prev_wb_len   = nil  -- previous writeback range length
+  local flushed       = 0
+  local sent          = 0
+  local client_alive  = send_to_client
+
+  -- Windowed slice parameters (for tee_stream_range_window)
+  local slice_start = client_opts and client_opts.start or 0
+  local slice_end   = client_opts and client_opts.stop  -- nil = end of body
+
+  -- How to decide what bytes to send to client
+  local function maybe_send_slice(chunk, chunk_start)
+    if not client_alive then return 0 end
+    local chunk_len = #chunk
+    local chunk_end_pos = chunk_start + chunk_len - 1
+
+    -- If windowed mode
+    if client_opts then
+      local s_end = slice_end or (chunk_end_pos + 1)  -- default: no upper bound
+      if chunk_end_pos < slice_start or chunk_start > s_end then return 0 end
+      local from = math.max(slice_start - chunk_start, 0) + 1
+      local to   = math.min(s_end - chunk_start + 1, chunk_len)
+      local slice = chunk:sub(from, to)
+      if #slice > 0 then
+        local okp = pcall(ngx.print, slice)
+        if not okp then client_alive = false; return 0 end
+        return #slice
+      end
+      return 0
+    else
+      -- Full body mode
+      local okp = pcall(ngx.print, chunk)
+      if not okp then client_alive = false; return 0 end
+      return #chunk
+    end
+  end
+
+  local pos = 0 -- absolute position in upstream body
+
+  if res.body_reader then
+    while true do
+      local chunk, cerr = res.body_reader(32768)
+      if cerr then
+        ngx.log(ngx.WARN, "[streamcache] tee read error: ", tostring(cerr))
+        return 0, 0, "upstream_read_fail"
+      end
+      if not chunk then break end
+
+      -- 1. Write to disk via FFI
+      local written, errw = File.write_fd(fd, chunk)
+      if not written or written ~= #chunk then
+        ngx.log(ngx.ERR, "[streamcache] write failed: ", tostring(errw), " rid=", rid)
+        return total_written, sent, "disk_write_fail"
+      end
+      total_written = total_written + #chunk
+
+      -- 2. Progress + inflight TTL refresh
+      if (total_written - last_report) >= cfg.PROGRESS_FLUSH_BYTES then
+        progress:set(key, total_written, cfg.INFLIGHT_TTL)
+        last_report = total_written
+        -- Keep totals alive
+        local exp = totals:get(key)
+        if exp then refresh_totals(totals, key, tonumber(exp), cfg.TOTALS_TTL_SECS) end
+        -- Refresh inflight lock so it doesn't expire during long downloads
+        inflight:set(key, true, cfg.INFLIGHT_TTL)
+      end
+
+      -- 3. Page cache management: pipeline writeback + drop
+      --    Step A: drop the PREVIOUS range (writeback was started last cycle)
+      --    Step B: start async writeback of the CURRENT range
+      --    This overlaps disk I/O with network I/O for zero extra latency.
+      if (total_written - last_fadvise) >= cfg.FADVISE_CHUNK then
+        -- Drop previous range (its writeback was started last iteration)
+        if prev_wb_off then
+          File.drop_cache(fd, prev_wb_off, prev_wb_len)
+        end
+        -- Start async writeback of current range
+        local cur_off = last_fadvise
+        local cur_len = total_written - last_fadvise
+        File.start_writeback(fd, cur_off, cur_len)
+        prev_wb_off = cur_off
+        prev_wb_len = cur_len
+        last_fadvise = total_written
+      end
+
+      -- 4. Send to client (full body or windowed slice)
+      sent = sent + maybe_send_slice(chunk, pos)
+      pos = pos + #chunk
+
+      if client_alive then
+        flushed = flushed + #chunk
+        if flushed >= cfg.CLIENT_FLUSH_BYTES then ngx.flush(true); flushed = 0 end
+      else
+        -- No client: yield to event loop so kernel can flush dirty pages
+        -- and other timers/connections get CPU time. Without this, the
+        -- write loop runs at wire speed and starves everything.
+        ngx.sleep(0)
+      end
+    end
+  elseif res.body then
+    local chunk = res.body
+    total_written = #chunk
+    local written, errw = File.write_fd(fd, chunk)
+    if not written or written ~= #chunk then
+      ngx.log(ngx.ERR, "[streamcache] write failed: ", tostring(errw), " rid=", rid)
+      return total_written, sent, "disk_write_fail"
+    end
+    progress:set(key, total_written, cfg.INFLIGHT_TTL)
+    local exp = totals:get(key)
+    if exp then refresh_totals(totals, key, tonumber(exp), cfg.TOTALS_TTL_SECS) end
+    inflight:set(key, true, cfg.INFLIGHT_TTL)
+    sent = sent + maybe_send_slice(chunk, pos)
+    pos = pos + #chunk
+  end
+
+  -- Final page cache cleanup: drop any remaining pages
+  -- First, drop the previous writeback range if pending
+  if prev_wb_off then
+    File.drop_cache(fd, prev_wb_off, prev_wb_len)
+  end
+  -- Then flush + drop the tail
+  if total_written > last_fadvise then
+    File.drop_cache(fd, last_fadvise, total_written - last_fadvise)
+  end
+
+  -- Final progress update
+  progress:set(key, total_written, cfg.INFLIGHT_TTL)
+
+  if client_alive then ngx.flush(true) end
+
+  return total_written, sent, nil
+end
+
+-- ======================== Strict Commit ========================
+-- Only commits (renames .part → final) if written bytes exactly match
+-- expected size. Uses chunked copy fallback + post-commit verification.
+local function strict_commit(ctx, tmp, dest_path, total_written, rid)
+  local totals  = ctx.shared.totals
+  local access  = ctx.shared.access
+  local cfg     = ctx.config
+  local key     = ctx.key
+
+  local expected = tonumber(totals:get(key) or 0)
+  if expected > 0 then
+    if total_written == expected then
+      local okr, errr = File.rename(tmp, dest_path, expected)
+      if not okr then
+        ngx.log(ngx.ERR, "[streamcache] commit failed: ", tostring(errr),
+          " tmp=", tmp, " dest=", dest_path, " rid=", rid)
+        File.remove(tmp)
+        return false, "commit_fail"
+      end
+      local ts = ngx.now()
+      File.write_meta(key, total_written, ts, cfg.META_DIR)
+      access:set(key, ts)
+      if cfg.VERBOSE then
+        Utils.jlog(ngx.NOTICE, "tee_complete",
+          {size = Utils.b2human(total_written), expected = tostring(expected)}, rid, true)
+      end
+      return true, nil
+    else
+      File.remove(tmp)
+      ngx.log(ngx.WARN, "[streamcache] not committing (truncated): written=",
+        tostring(total_written), " expected=", tostring(expected), " key=", key)
+      return false, "size_mismatch"
+    end
+  else
+    File.remove(tmp)
+    if total_written > 0 then
+      ngx.log(ngx.WARN, "[streamcache] not committing (unknown total size); key=", key,
+        " written=", tostring(total_written))
+    else
+      ngx.log(ngx.WARN, "[streamcache] tee produced 0 bytes; not committing key=", key)
+    end
+    return false, "unknown_size"
+  end
+end
+
+-- ======================== tee_stream ========================
+-- Full-body tee: upstream → client (optional) + disk.
+-- send_to_client=true:  sets response headers and streams body to client
+-- send_to_client=false: writer-only mode (background timer); no ngx.print
+function Tee.tee_stream(ctx, url, dest_path, use_range_0, client_headers, send_to_client)
+  if send_to_client == nil then send_to_client = true end
+  Utils.set_var_safe("sc_decision", "MISS_TEE")
+
+  local cfg = ctx.config
+  local key = ctx.key
+  local rid = ctx.rid
+  local inflight = ctx.shared.inflight
+  local totals   = ctx.shared.totals
+
+  -- Build headers
+  local ch = client_headers or ngx.req.get_headers()
+  local headers
+  if send_to_client then
+    headers = Upstream.build_client_like_headers(nil, url, ch)
+    local client_range = ch["Range"] or ch["range"]
+    if client_range and client_range ~= "" then
+      headers["Range"] = client_range
+    elseif use_range_0 then
+      headers["Range"] = "bytes=0-"
+    end
+  else
+    -- Writer-only: use captured client headers for detection avoidance
+    headers = Upstream.build_client_like_headers(nil, url, ch)
+    if use_range_0 then headers["Range"] = "bytes=0-" end
+    -- Don't forward client Range in writer mode — always fetch full file
+    if not use_range_0 then headers["Range"] = nil end
+  end
+
+  local res, httpc, final_url = Upstream.request(url, {
+    method     = "GET",
+    headers    = headers,
+    ssl_verify = cfg.SSL_VERIFY,
+  })
+  if not res then
+    return fail_exit(ngx.HTTP_BAD_GATEWAY, nil, key, nil, inflight, send_to_client)
+  end
+
+  -- Range-hostile fallback: retry without Range on 416/400/403
+  if not (res.status == 200 or res.status == 206) then
+    if headers["Range"] and (res.status == 416 or res.status == 400 or res.status == 403) then
+      httpc:close()
+      local res2, httpc2, url2 = range_hostile_retry(
+        url, {ssl_verify = cfg.SSL_VERIFY}, totals, key, cfg, url, ch)
+      if res2 and (res2.status == 200 or res2.status == 206) then
+        res, httpc, final_url = res2, httpc2, url2
+      else
+        if httpc2 then httpc2:close() end
+        return fail_exit(ngx.HTTP_BAD_GATEWAY, nil, key, nil, inflight, send_to_client)
+      end
+    else
+      ngx.log(ngx.WARN, "[streamcache] tee status not OK: ", res.status)
+      return fail_exit(ngx.HTTP_BAD_GATEWAY, httpc, key, nil, inflight, send_to_client)
+    end
+  end
+
+  -- Parse total size
+  local total_size, hl = parse_total_size(res)
+  if total_size and total_size > 0 then
+    refresh_totals(totals, key, total_size, cfg.TOTALS_TTL_SECS)
+  end
+
+  -- Cache origin headers for followers
+  cache_origin_headers(ctx.shared.resolved, key, res.headers)
+
+  -- Send response headers to client
+  if send_to_client then
+    local client_sent_range = (ch["Range"] or ch["range"]) ~= nil
+    local hcopy = Utils.filter_response_headers(res.headers)
+
+    if (not client_sent_range) and res.status == 206 then
+      hcopy["Content-Range"] = nil
+      if total_size and total_size > 0 then
+        hcopy["Content-Length"] = tostring(total_size)
+      else
+        hcopy["Content-Length"] = nil
+      end
+      ngx.status = ngx.HTTP_OK
+    else
+      ngx.status = res.status
+    end
+    for k, v in pairs(hcopy) do ngx.header[k] = v end
+    ngx.send_headers()
+  end
+
+  -- Open temp file via FFI
+  File.ensure_dirs(cfg.TMP_DIR)
+  local tmp = cfg.TMP_DIR .. "/" .. key .. ".part"
+  File.remove(tmp)
+  local fd, err_open = File.open_fd(tmp)
+  if not fd then
+    ngx.log(ngx.ERR, "[streamcache] tee cannot open temp (fd): ", tmp, " err=", tostring(err_open))
+    return fail_exit(ngx.HTTP_BAD_GATEWAY, httpc, key, nil, inflight, send_to_client)
+  end
+
+  -- Stream & write
+  local total_written, _, loop_err = write_loop(ctx, res, httpc, fd, tmp, send_to_client, nil)
+
+  File.fsync_fd(fd)
+  File.close_fd(fd)
+  httpc:close()
+
+  if loop_err then
+    cleanup_writer(nil, key, tmp, inflight)
+    return
+  end
+
+  -- Strict commit
+  strict_commit(ctx, tmp, dest_path, total_written, rid)
+  inflight:delete(key)
+  return
+end
+
+-- ======================== tee_stream_range_window ========================
+-- Cache full body from byte 0; serve client only the requested slice.
+-- This optimizes IPTV playback startup: client gets its requested range
+-- with low latency while the full file is cached in the background.
+function Tee.tee_stream_range_window(ctx, url, dest_path, client_start, client_end,
+                                      client_headers, send_to_client)
+  if send_to_client == nil then send_to_client = true end
+  Utils.set_var_safe("sc_decision", "MISS_TEE_WINDOW")
+
+  local cfg = ctx.config
+  local key = ctx.key
+  local rid = ctx.rid
+  local inflight = ctx.shared.inflight
+  local totals   = ctx.shared.totals
+
+  local ch = client_headers or ngx.req.get_headers()
+  local headers = Upstream.build_client_like_headers(nil, url, ch)
+  headers["Range"] = (ch["Range"] or ch["range"]) or "bytes=0-"
+
+  local res, httpc, final_url = Upstream.request(url, {
+    method     = "GET",
+    headers    = headers,
+    ssl_verify = cfg.SSL_VERIFY,
+  })
+  if not res then
+    return fail_exit(ngx.HTTP_BAD_GATEWAY, nil, key, nil, inflight, send_to_client)
+  end
+
+  -- Range-hostile fallback
+  if not (res.status == 200 or res.status == 206) then
+    if headers["Range"] and (res.status == 416 or res.status == 400 or res.status == 403) then
+      httpc:close()
+      local res2, httpc2, url2 = range_hostile_retry(
+        url, {ssl_verify = cfg.SSL_VERIFY}, totals, key, cfg, url, ch)
+      if res2 and (res2.status == 200 or res2.status == 206) then
+        res, httpc, final_url = res2, httpc2, url2
+      else
+        if httpc2 then httpc2:close() end
+        return fail_exit(ngx.HTTP_BAD_GATEWAY, nil, key, nil, inflight, send_to_client)
+      end
+    else
+      ngx.log(ngx.WARN, "[streamcache] tee-window status not OK: ", res.status)
+      return fail_exit(ngx.HTTP_BAD_GATEWAY, httpc, key, nil, inflight, send_to_client)
+    end
+  end
+
+  -- Parse total size
+  local total_size, hl = parse_total_size(res)
+  if total_size and total_size > 0 then
+    refresh_totals(totals, key, total_size, cfg.TOTALS_TTL_SECS)
+  end
+
+  -- Cache origin headers for followers
+  cache_origin_headers(ctx.shared.resolved, key, res.headers)
+
+  -- If size unknown, fall back to nocache streaming
+  if not total_size or total_size <= 0 then
+    httpc:close()
+    inflight:delete(key)
+    local NoCache = require "sc_nocache"
+    return NoCache.stream(url, cfg, ch, false)
+  end
+
+  -- Compute client slice bounds
+  local send_start = math.max(0, tonumber(client_start) or 0)
+  local send_end   = tonumber(client_end)
+  if not send_end or send_end > (total_size - 1) then send_end = total_size - 1 end
+  if send_start > send_end then
+    httpc:close()
+    inflight:delete(key)
+    ngx.header["Content-Range"] = string.format("bytes */%d", total_size)
+    return ngx.exit(ngx.HTTP_REQUESTED_RANGE_NOT_SATISFIABLE)
+  end
+  local send_len = send_end - send_start + 1
+
+  -- Send 206 headers to client
+  if send_to_client then
+    local hcopy = {}
+    for k, v in pairs(res.headers or {}) do
+      local kl = string.lower(k)
+      if kl == "content-type" or kl == "etag" or kl == "last-modified"
+         or kl == "content-disposition" then
+        hcopy[k] = v
+      end
+    end
+    hcopy["Accept-Ranges"]  = "bytes"
+    hcopy["Content-Range"]  = string.format("bytes %d-%d/%d", send_start, send_end, total_size)
+    hcopy["Content-Length"]  = tostring(send_len)
+    ngx.status = ngx.HTTP_PARTIAL_CONTENT
+    for k, v in pairs(hcopy) do ngx.header[k] = v end
+    ngx.send_headers()
+  end
+
+  -- Open temp file via FFI
+  File.ensure_dirs(cfg.TMP_DIR)
+  local tmp = cfg.TMP_DIR .. "/" .. key .. ".part"
+  File.remove(tmp)
+  local fd, err_open = File.open_fd(tmp)
+  if not fd then
+    ngx.log(ngx.ERR, "[streamcache] tee-window cannot open temp (fd): ", tmp,
+      " err=", tostring(err_open), " ; falling back to nocache")
+    httpc:close()
+    inflight:delete(key)
+    local NoCache = require "sc_nocache"
+    return NoCache.stream(url, cfg, ch, false)
+  end
+
+  -- Stream & write with windowed client output
+  local total_written, _, loop_err = write_loop(
+    ctx, res, httpc, fd, tmp, send_to_client,
+    { start = send_start, stop = send_end }
+  )
+
+  File.fsync_fd(fd)
+  File.close_fd(fd)
+  httpc:close()
+
+  if loop_err then
+    cleanup_writer(nil, key, tmp, inflight)
+    return
+  end
+
+  -- Strict commit
+  strict_commit(ctx, tmp, dest_path, total_written, rid)
+  inflight:delete(key)
+  return
+end
+
+return Tee

--- a/conf/lib/sc_upstream.lua
+++ b/conf/lib/sc_upstream.lua
@@ -1,0 +1,225 @@
+-- sc_upstream.lua
+-- HTTP client with centralized redirect following.
+-- All upstream communication goes through this module for consistent
+-- header handling and detection-avoidance behavior.
+
+local http  = require "resty.http"
+local ngx   = ngx
+local Utils = require "sc_utils"
+
+local Upstream = {}
+
+-- ======================== URL Parsing ========================
+
+function Upstream.split_hostport(authority, scheme)
+  if not authority or authority == "" then return nil, nil end
+  -- IPv6 with port: [::1]:8080
+  local h, p = authority:match("^%[(.-)%]:(%d+)$")
+  if h then return h, tonumber(p) end
+  -- IPv6 without port: [::1]
+  h = authority:match("^%[(.-)%]$")
+  if h then return h, (scheme == "https" and 443 or 80) end
+  -- IPv4/hostname with port
+  h, p = authority:match("^([^:]+):(%d+)$")
+  if h then return h, tonumber(p) end
+  -- Bare hostname
+  return authority, (scheme == "https" and 443 or 80)
+end
+
+function Upstream.parse_url(u)
+  if not u then return nil end
+  local scheme, rest = u:match("^(https?)://(.+)$")
+  if not scheme then return nil end
+  local authority, path = rest:match("^([^/]+)(/.*)$")
+  authority = authority or rest
+  path = path or "/"
+  local host, port = Upstream.split_hostport(authority, scheme)
+  if not host then return nil end
+  local def = (scheme == "https" and 443 or 80)
+  port = port or def
+  local host_header = (port == def) and host or (host .. ":" .. tostring(port))
+  return scheme, host, port, path, host_header
+end
+
+-- Resolve a relative or absolute Location header against the current URL.
+function Upstream.resolve_location(current, scheme, host, loc)
+  if not loc or loc == "" then return nil end
+  if loc:match("^https?://") then return loc end
+  if loc:match("^//")        then return scheme .. ":" .. loc end
+  if loc:match("^[^/]+:%d+/.") or loc:match("^[^/]+/") then
+    return scheme .. "://" .. loc
+  end
+  if loc:sub(1, 1) == "/" then return scheme .. "://" .. host .. loc end
+  local base = current:match("^(https?://[^?]+)")
+  local dir  = base and base:match("(.*/)") or (scheme .. "://" .. host .. "/")
+  return dir .. loc
+end
+
+-- ======================== Header Building (Detection Avoidance) ========================
+
+-- Build upstream request headers that mimic the downstream client.
+-- DETECTION AVOIDANCE: forwards all meaningful client headers so the
+-- upstream provider sees traffic indistinguishable from a direct player.
+--
+-- client_headers: table of headers to forward (from ngx.req.get_headers()
+--   or captured before timer). Pass nil to read from current request.
+-- host_header: override Host (set per-hop during redirect following)
+-- orig_url: used as Referer fallback
+function Upstream.build_client_like_headers(host_header, orig_url, client_headers)
+  local ch = client_headers or ngx.req.get_headers()
+  local h = {
+    ["Host"]                  = host_header,
+    ["User-Agent"]            = ch["User-Agent"] or ch["user-agent"],
+    ["Accept"]                = ch["Accept"] or ch["accept"],
+    ["Accept-Language"]       = ch["Accept-Language"] or ch["accept-language"],
+    ["Accept-Encoding"]       = ch["Accept-Encoding"] or ch["accept-encoding"],
+    ["Referer"]               = ch["Referer"] or ch["referer"] or orig_url,
+    ["Origin"]                = ch["Origin"] or ch["origin"],
+    ["Cookie"]                = ch["Cookie"] or ch["cookie"],
+    ["Authorization"]         = ch["Authorization"] or ch["authorization"],
+    -- Emby/Jellyfin specific
+    ["X-Playback-Session-Id"] = ch["X-Playback-Session-Id"] or ch["x-playback-session-id"],
+    -- Conditional request headers (may be sent by seeking players)
+    ["If-Range"]              = ch["If-Range"] or ch["if-range"],
+    ["If-None-Match"]         = ch["If-None-Match"] or ch["if-none-match"],
+    ["If-Modified-Since"]     = ch["If-Modified-Since"] or ch["if-modified-since"],
+  }
+  -- Strip nil/empty values
+  local out = {}
+  for k, v in pairs(h) do
+    if v and v ~= "" then out[k] = v end
+  end
+  -- Ensure we always have a User-Agent (critical for detection avoidance)
+  if not out["User-Agent"] then
+    out["User-Agent"] = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+  end
+  return out
+end
+
+-- ======================== Low-Level Connection ========================
+
+local function connect_raw(host, port, scheme, ssl_verify)
+  local httpc = http.new()
+  httpc:set_timeouts(5000, 5000, 0) -- 5s connect/send, infinite read (streaming)
+  local ok, err = httpc:connect(host, port)
+  if not ok then return nil, "connect_failed: " .. tostring(err) end
+  if scheme == "https" then
+    local ok2, err2 = httpc:ssl_handshake(nil, host, ssl_verify)
+    if not ok2 then
+      httpc:close()
+      return nil, "ssl_failed: " .. tostring(err2)
+    end
+  end
+  return httpc, nil
+end
+
+-- ======================== Centralized Request with Redirect Following ========================
+
+-- Performs an HTTP request with automatic redirect following (up to max_redirects).
+-- Returns: res, httpc, final_url  OR  nil, err_string, nil
+--
+-- The caller MUST close httpc when done (after consuming body).
+-- This eliminates duplicated redirect loops across nocache/tee/head paths.
+function Upstream.request(url, options)
+  options = options or {}
+  local method        = options.method or "GET"
+  local max_redirects = options.max_redirects or 5
+  local ssl_verify    = (options.ssl_verify ~= false)
+
+  local current_url = url
+  local hops = 0
+  local httpc, res, err
+
+  while hops <= max_redirects do
+    local scheme, host, port, path, host_header = Upstream.parse_url(current_url)
+    if not scheme then return nil, "invalid_url_parse", nil end
+
+    httpc, err = connect_raw(host, port, scheme, ssl_verify)
+    if not httpc then return nil, err, nil end
+
+    -- Prepare headers: clone to avoid mutation, set Host per-hop
+    local headers = Utils.tclone(options.headers or {})
+    headers["Host"] = host_header
+
+    res, err = httpc:request({
+      method  = method,
+      path    = path,
+      headers = headers,
+    })
+
+    if not res then
+      httpc:close()
+      return nil, "request_failed: " .. tostring(err), nil
+    end
+
+    -- Follow redirects (301, 302, 303, 307, 308)
+    if res.status >= 300 and res.status < 400 and res.status ~= 304 then
+      local loc = res.headers and (res.headers["Location"] or res.headers["location"])
+      httpc:close()
+      if not loc then return nil, "redirect_no_location", nil end
+      local next_url = Upstream.resolve_location(current_url, scheme, host_header, loc)
+      if not next_url then return nil, "redirect_resolve_failed", nil end
+      current_url = next_url
+      hops = hops + 1
+    else
+      -- Non-redirect response: return open connection for streaming
+      return res, httpc, current_url
+    end
+  end
+
+  return nil, "too_many_redirects", nil
+end
+
+-- ======================== Header Probing ========================
+
+-- Fetch origin response headers via HEAD (falls back to GET 0-0 if HEAD
+-- returns 405). Used by followers to get Content-Type, ETag, etc.
+-- Returns a table of lowercased header keys → values.
+function Upstream.fetch_origin_headers(url, hdrs, ssl_verify)
+  local scheme, host, port, path, host_header = Upstream.parse_url(url)
+  if not scheme then return {} end
+
+  local httpc = http.new()
+  httpc:set_timeouts(3000, 3000, 3000)
+  local ok = httpc:connect(host, port)
+  if not ok then return {} end
+  if scheme == "https" then
+    local ok2 = httpc:ssl_handshake(nil, host, ssl_verify ~= false)
+    if not ok2 then httpc:close(); return {} end
+  end
+
+  local headers = Utils.tclone(hdrs or {})
+  headers["Host"] = host_header
+  if not headers["User-Agent"] then
+    headers["User-Agent"] = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+  end
+
+  local res = select(1, httpc:request{ method = "HEAD", path = path, headers = headers })
+  if (not res) or res.status == 405 then
+    headers["Range"] = headers["Range"] or "bytes=0-0"
+    res = select(1, httpc:request{ method = "GET", path = path, headers = headers })
+  end
+  if not res then httpc:close(); return {} end
+
+  local out = {}
+  for k, v in pairs(res.headers or {}) do out[string.lower(k)] = v end
+  httpc:close()
+  return out
+end
+
+-- Probe expected total size using HEAD (preferred) or 0-0 GET fallback.
+-- Returns: total_size (number or nil), accept_ranges (boolean)
+function Upstream.probe_total_with_head(url, hdrs, ssl_verify)
+  local oh = Upstream.fetch_origin_headers(url, hdrs, ssl_verify)
+  local total, accept_ranges = nil, false
+  if oh["content-range"] then
+    local t0 = oh["content-range"]:match("/(%d+)$")
+    if t0 then total = tonumber(t0) end
+  elseif oh["content-length"] then
+    total = tonumber(oh["content-length"])
+  end
+  if oh["accept-ranges"] == "bytes" then accept_ranges = true end
+  return total, accept_ranges
+end
+
+return Upstream

--- a/conf/lib/sc_utils.lua
+++ b/conf/lib/sc_utils.lua
@@ -1,0 +1,82 @@
+-- sc_utils.lua
+-- Shared helpers used across all modules.
+
+local ngx = ngx
+
+local Utils = {}
+
+function Utils.b2human(n)
+  if not n or n < 0 then return "0 B" end
+  local u = {"B","KB","MB","GB","TB","PB"}; local i = 1
+  while n >= 1024 and i < #u do n = n / 1024; i = i + 1 end
+  return string.format("%.2f %s", n, u[i])
+end
+
+-- Safe setter for nginx vars (no-ops outside request phases or timer context)
+function Utils.set_var_safe(name, value)
+  local phase = ngx.get_phase()
+  if phase == "rewrite" or phase == "access" or phase == "content" or phase == "log" then
+    pcall(function() ngx.var[name] = value end)
+  end
+end
+
+-- Shallow clone
+function Utils.tclone(t)
+  local o = {}
+  if not t then return o end
+  for k, v in pairs(t) do o[k] = v end
+  return o
+end
+
+-- Base64-URL decode (URL-safe variant with - and _)
+function Utils.b64url_decode(s)
+  s = s:gsub("-", "+"):gsub("_", "/")
+  local pad = #s % 4
+  if pad > 0 then s = s .. string.rep("=", 4 - pad) end
+  return ngx.decode_base64(s)
+end
+
+function Utils.key_from_url(u)
+  return ngx.md5(u)
+end
+
+-- Structured JSON-ish logging (only emits when verbose is true)
+function Utils.jlog(level, event, fields, rid, verbose)
+  if not verbose then return end
+  fields = fields or {}
+  fields.rid = rid
+  local buf = {}
+  for k, v in pairs(fields) do
+    buf[#buf + 1] = string.format('"%s":"%s"', k, tostring(v))
+  end
+  ngx.log(level, "[streamcache] ", event, " {", table.concat(buf, ","), "}")
+end
+
+-- Standard hop-by-hop headers that must never be forwarded to clients.
+-- Used by all response-sending code paths for consistent filtering.
+Utils.HOP_BY_HOP = {
+  ["transfer-encoding"]    = true,
+  ["connection"]           = true,
+  ["keep-alive"]           = true,
+  ["proxy-authenticate"]   = true,
+  ["proxy-authorization"]  = true,
+  ["te"]                   = true,
+  ["trailer"]              = true,
+  ["upgrade"]              = true,
+  ["location"]             = true,  -- never expose redirects to client
+}
+
+-- Filter response headers: strips hop-by-hop + adds cache metadata.
+-- Returns a clean header table ready for ngx.header assignment.
+function Utils.filter_response_headers(raw_headers)
+  local out = {}
+  for k, v in pairs(raw_headers or {}) do
+    if not Utils.HOP_BY_HOP[string.lower(k)] then
+      out[k] = v
+    end
+  end
+  out["Accept-Ranges"] = "bytes"
+  return out
+end
+
+return Utils

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -29,7 +29,7 @@ http {
   keepalive_timeout 65;
 
   # Lua module paths (for resty.http)
-  lua_package_path  "/usr/local/openresty/site/lualib/?.lua;/usr/local/openresty/lualib/?.lua;;";
+  lua_package_path  "/etc/openresty/lib/?.lua;/usr/local/openresty/site/lualib/?.lua;/usr/local/openresty/lualib/?.lua;;";
   lua_package_cpath "/usr/local/openresty/site/lualib/?.so;/usr/local/openresty/lualib/?.so;;";
 
   # DNS for upstreams

--- a/conf/streamcache.conf
+++ b/conf/streamcache.conf
@@ -11,6 +11,7 @@ server {
 
     # Main endpoint: /u/<BASE64URL-ENCODED-ORIGINAL-URL>
     location ~ ^/u/(?<b64>[-_A-Za-z0-9=]+)$ {
+        lua_check_client_abort on;
         content_by_lua_file /etc/openresty/streamcache.lua;
     }
 

--- a/conf/streamcache.lua
+++ b/conf/streamcache.lua
@@ -1,1013 +1,127 @@
 -- streamcache.lua
+-- Entry point: routing logic only.
 -- Single-pass tee + redirect-follow; never leak Location/30x to clients.
-
-local ngx  = ngx
-local os   = os
-local http = require "resty.http"
-
-
-
--- Safe setter for nginx vars (no-ops outside request phases)
-local function set_var_safe(name, value)
-  local phase = ngx.get_phase()
-  if phase == "rewrite" or phase == "access" or phase == "content" or phase == "log" then
-    pcall(function() ngx.var[name] = value end)
-  end
-end
-
--- ===================== Config (via env) =====================
-local VERBOSE               = (os.getenv("LOG_VERBOSE") == "1")
-local RANGE_TEE_THRESHOLD   = tonumber(os.getenv("RANGE_TEE_THRESHOLD")   or "") or (5 * 1024 * 1024) -- 5 MiB
-local PROGRESS_FLUSH_BYTES  = tonumber(os.getenv("PROGRESS_FLUSH_BYTES")  or "") or 262144            -- 256 KiB
-local FOLLOWER_WAIT_MAX     = tonumber(os.getenv("FOLLOWER_WAIT_MAX")     or "") or 600              -- seconds
-local FOLLOWER_POLL_MS      = tonumber(os.getenv("FOLLOWER_POLL_MS")      or "") or 50               -- ms
--- New: short startup wait for followers so we don't open a duplicate upstream
-local FOLLOWER_START_WAIT_MS= tonumber(os.getenv("FOLLOWER_START_WAIT_MS")or "") or 750              -- ms
-local FOLLOWER_MIN_BYTES       = tonumber(os.getenv("FOLLOWER_MIN_BYTES") or "") or 65536 -- 64 KiB default
--- New: batch client flushes to reduce syscall and allocator pressure
-local CLIENT_FLUSH_BYTES    = tonumber(os.getenv("CLIENT_FLUSH_BYTES")    or "") or (1 * 1024 * 1024) -- 1 MiB
--- New: how long to retain the known TOTAL size (refresh while downloading)
-local TOTALS_TTL_SECS       = tonumber(os.getenv("TOTALS_TTL_SECS")       or "") or 86400            -- 24h
-local SSL_VERIFY            = (os.getenv("DISABLE_SSL_VERIFY") ~= "1")
-
--- Correlation id and structured logging helper
-local RID = ngx.var.request_id or tostring(ngx.now())
-local function jlog(level, event, fields)
-  if not VERBOSE then return end
-  fields = fields or {}
-  fields.rid = RID
-  local buf = {}
-  for k,v in pairs(fields) do
-    buf[#buf+1] = string.format('"%s":"%s"', k, tostring(v))
-  end
-  ngx.log(level, "[streamcache] ", event, " {", table.concat(buf, ","), "}")
-end
-
--- ===================== Helpers =====================
-local function b2human(n)
-  if not n or n < 0 then return "0 B" end
-  local u = {"B","KB","MB","GB","TB","PB"}; local i=1
-  while n >= 1024 and i < #u do n = n/1024; i = i+1 end
-  return string.format("%.2f %s", n, u[i])
-end
-
-local function write_meta(key, size, last)
-  local d = "/var/cache/streamcache/meta"
-  os.execute("mkdir -p " .. d)
-  local f = io.open(d .. "/" .. key .. ".meta", "wb")
-  if not f then return end
-  f:write("size=" .. tostring(size or 0) .. "\n")
-  f:write("last_access=" .. tostring(last or ngx.now()) .. "\n")
-  f:close()
-end
-
-local function b64url_decode(s)
-  s = s:gsub("-", "+"):gsub("_", "/")
-  local pad = #s % 4
-  if pad > 0 then s = s .. string.rep("=", 4 - pad) end
-  return ngx.decode_base64(s)
-end
-
-local function file_exists(p)
-  local f=io.open(p,"rb"); if f then f:close(); return true end; return false
-end
-
-local function file_size(p)
-  local f=io.open(p,"rb"); if not f then return 0 end; local sz=f:seek("end"); f:close(); return sz or 0
-end
-
-local function key_from_url(u) return ngx.md5(u) end
-
--- URL parsing
-local function split_hostport(authority, scheme)
-  if not authority or authority == "" then return nil, nil end
-  local h,p = authority:match("^%[(.-)%]:(%d+)$"); if h then return h, tonumber(p) end
-  h = authority:match("^%[(.-)%]$"); if h then return h, (scheme=="https" and 443 or 80) end
-  h,p = authority:match("^([^:]+):(%d+)$"); if h then return h, tonumber(p) end
-  return authority, (scheme=="https" and 443 or 80)
-end
-
-local function parse_url(u)
-  if not u then return nil end
-  local scheme, rest = u:match("^(https?)://(.+)$"); if not scheme then return nil end
-  local authority, path = rest:match("^([^/]+)(/.*)$"); authority=authority or rest; path=path or "/"
-  local host, port = split_hostport(authority, scheme); if not host then return nil end
-  local def = (scheme=="https" and 443 or 80); port = port or def
-  local host_header = (port==def) and host or (host .. ":" .. tostring(port))
-  return scheme, host, port, path, host_header
-end
-
-local function resolve_location(current, scheme, host, loc)
-  if not loc or loc == "" then return nil end
-  if loc:match("^https?://") then return loc end
-  if loc:match("^//")       then return scheme .. ":" .. loc end
-  if loc:match("^[^/]+:%d+/.") or loc:match("^[^/]+/") then return scheme .. "://" .. loc end
-  if loc:sub(1,1) == "/"   then return scheme .. "://" .. host .. loc end
-  local base = current:match("^(https?://[^?]+)")
-  local dir  = base and base:match("(.*/)") or (scheme .. "://" .. host .. "/")
-  return dir .. loc
-end
-
-local function tclone(t) local o={}; if not t then return o end; for k,v in pairs(t) do o[k]=v end; return o end
-
-local function build_client_like_headers(host_header, orig_url)
-  local ch = ngx.req.get_headers()
-  local h = {
-    ["Host"]            = host_header,
-    ["User-Agent"]      = ch["User-Agent"],
-    ["Accept"]          = ch["Accept"],
-    ["Accept-Language"] = ch["Accept-Language"],
-    ["Accept-Encoding"] = ch["Accept-Encoding"],
-    ["Referer"]         = ch["Referer"] or orig_url,
-    ["Origin"]          = ch["Origin"],
-    ["Cookie"]          = ch["Cookie"],
-    ["Authorization"]   = ch["Authorization"],
-  }
-  for k,v in pairs(tclone(h)) do if v == nil or v == "" then h[k]=nil end end
-  return h
-end
-
--- Probe expected total size using HEAD (preferred) or 0-0 GET fallback.
--- Returns: total_size (number or nil), accept_ranges (boolean)
-local function probe_total_with_head(final_url, hdrs)
-  -- Reuse existing helper that already tries HEAD then GET bytes=0-0
-  local oh = fetch_origin_headers(final_url, hdrs or {})
-  local total, accept_ranges = nil, false
-  if oh["content-range"] then
-    local s0, e0, t0 = oh["content-range"]:match("^bytes%s+(%d+)%-(%d+)/(%d+)$")
-    if t0 then total = tonumber(t0) end
-  elseif oh["content-length"] then
-    total = tonumber(oh["content-length"])
-  end
-  if oh["accept-ranges"] == "bytes" then
-    accept_ranges = true
-  end
-  return total, accept_ranges
-end
-
--- Fetch a few headers (for follower friendliness)
-local function fetch_origin_headers(final_url, hdrs)
-  local scheme, host, port, path, host_header = parse_url(final_url)
-  if not scheme then return {} end
-  local httpc = http.new()
-  httpc:set_timeouts(3000, 3000, 3000)
-  local ok = httpc:connect(host, port); if not ok then return {} end
-  if scheme == "https" then
-    local ok2 = httpc:ssl_handshake(nil, host, SSL_VERIFY)
-    if not ok2 then httpc:close(); return {} end
-  end
-  local headers = tclone(hdrs or {}); headers["Host"] = host_header
-  if not headers["User-Agent"] then headers["User-Agent"] = "EmbyStreamCache/1.0" end
-  local res = select(1, httpc:request{ method="HEAD", path=path, headers=headers })
-  if (not res) or res.status == 405 then
-    headers["Range"] = headers["Range"] or "bytes=0-0"
-    res = select(1, httpc:request{ method="GET", path=path, headers=headers })
-  end
-  if not res then httpc:close(); return {} end
-  local out = {}; for k,v in pairs(res.headers or {}) do out[string.lower(k)] = v end
-  httpc:close(); return out
-end
-
--- ===================== Shared dicts =====================
-local inflight = ngx.shared.inflight
-local access   = ngx.shared.access
-local resolved = ngx.shared.resolved -- kept for future hints
-local progress = ngx.shared.progress
-local totals   = ngx.shared.totals
-
--- Refresh helper: keep the expected total alive during long/throttled downloads
-local function refresh_totals(key, size)
-  if not key or not size or size <= 0 then return end
-  totals:set(key, size, TOTALS_TTL_SECS) -- set() refreshes TTL
-end
-
-
--- ===================== Timer-safe cleanup & exit helpers =====================
--- Clean up resources safely in both request and timer contexts.
-local function cleanup_writer(httpc, key, tmp)
-  -- close upstream connection
-  pcall(function() if httpc then httpc:close() end end)
-  -- remove temp file if present
-  if tmp and tmp ~= "" then pcall(os.remove, tmp) end
-  -- clear inflight flag
-  if key then inflight:delete(key) end
-end
-
--- Unified failure handler:
--- In request context (send_to_client=true) -> ngx.exit(code)
--- In timer context (send_to_client=false)  -> just return after cleanup
-local function fail_exit(code, httpc, key, tmp, send_to_client)
-  cleanup_writer(httpc, key, tmp)
-  if send_to_client then
-    return ngx.exit(code)
-  else
-    return  -- timer context: no ngx.exit
-  end
-end
-
--- ===================== No-cache streamer (far-seek passthrough & HEAD) =====================
-local function stream_no_cache(url, normalize_200_when_no_client_range)
-  set_var_safe("sc_decision", (ngx.var.sc_decision ~= "" and ngx.var.sc_decision) or "MISS_NO_CACHE")
-  local scheme, host, port, path, host_header = parse_url(url)
-  if not scheme then return ngx.exit(ngx.HTTP_BAD_GATEWAY) end
-
-  local httpc = http.new()
-  httpc:set_timeouts(5000, 5000, 0)
-
-  local function connect_to(h, p, sch)
-    local ok, err = httpc:connect(h, p)
-    if not ok then ngx.log(ngx.WARN, "[streamcache] nocache connect failed: ", tostring(err)); return nil end
-    if sch == "https" then
-      local ok2, err2 = httpc:ssl_handshake(nil, h, SSL_VERIFY)
-      if not ok2 then ngx.log(ngx.WARN, "[streamcache] nocache TLS failed: ", tostring(err2)); return nil end
-    end
-    return true
-  end
-
-  if not connect_to(host, port, scheme) then httpc:close(); return ngx.exit(ngx.HTTP_BAD_GATEWAY) end
-
-  local ch = ngx.req.get_headers()
-  local headers = build_client_like_headers(host_header, url)
-  headers["Range"] = ch["Range"] -- passthrough range as-is
-
-  local hops, res, rerr = 0, nil, nil
-  while true do
-    res, rerr = httpc:request{ method = "GET", path = path, headers = headers }
-    if not res then ngx.log(ngx.WARN, "[streamcache] nocache request failed: ", tostring(rerr)); httpc:close(); return ngx.exit(ngx.HTTP_BAD_GATEWAY) end
-    if (res.status == 301 or res.status == 302 or res.status == 303 or res.status == 307 or res.status == 308) then
-      if hops >= 5 then ngx.log(ngx.WARN, "[streamcache] nocache too many redirects"); httpc:close(); return ngx.exit(ngx.HTTP_BAD_GATEWAY) end
-      local loc = res.headers and (res.headers["Location"] or res.headers["location"])
-      httpc:close()
-      local next_url = resolve_location(url, scheme, host_header, loc)
-      if not next_url then return ngx.exit(ngx.HTTP_BAD_GATEWAY) end
-      url = next_url
-      scheme, host, port, path, host_header = parse_url(url)
-      if not scheme then return ngx.exit(ngx.HTTP_BAD_GATEWAY) end
-      if not connect_to(host, port, scheme) then httpc:close(); return ngx.exit(ngx.HTTP_BAD_GATEWAY) end
-      headers["Host"] = host_header
-      hops = hops + 1
-    else
-      break
-    end
-  end
-
-  local client_sent_range = (ch["Range"] ~= nil)
-  local hl = {}; for k,v in pairs(res.headers or {}) do hl[string.lower(k)] = v end
-  local total_size = nil
-  if hl["content-range"] then
-    local s0,e0,t0 = hl["content-range"]:match("^bytes%s+(%d+)%-(%d+)/(%d+)$")
-    if t0 then total_size = tonumber(t0) end
-  end
-  if not total_size and hl["content-length"] and res.status == 200 then
-    total_size = tonumber(hl["content-length"])
-  end
-
-  local hcopy = {}
-  for k,v in pairs(res.headers or {}) do
-    local kl = string.lower(k)
-    if kl ~= "transfer-encoding" and kl ~= "connection" and kl ~= "keep-alive"
-       and kl ~= "proxy-authenticate" and kl ~= "proxy-authorization"
-       and kl ~= "te" and kl ~= "trailer" and kl ~= "upgrade"
-       and kl ~= "location" then -- never expose redirects
-      hcopy[k] = v
-    end
-  end
-  hcopy["X-Cache"] = "MISS"
-  hcopy["Accept-Ranges"] = "bytes"
-
-  if normalize_200_when_no_client_range and (not client_sent_range) and res.status == 206 then
-    hcopy["Content-Range"] = nil
-    if total_size and total_size > 0 then
-      hcopy["Content-Length"] = tostring(total_size)
-    else
-      hcopy["Content-Length"] = nil
-    end
-    ngx.status = ngx.HTTP_OK
-  else
-    ngx.status = res.status
-  end
-
-  for k,v in pairs(hcopy) do ngx.header[k]=v end
-  ngx.send_headers()
-
-  -- Batch client flushes
-  local flushed = 0
-  if res.body_reader then
-    while true do
-      local chunk, cerr = res.body_reader(32768)
-      if cerr then ngx.log(ngx.WARN,"[streamcache] nocache read error: ", tostring(cerr)); httpc:close(); return ngx.exit(ngx.HTTP_BAD_GATEWAY) end
-      if not chunk then break end
-      local okp = pcall(ngx.print, chunk)
-      if okp then
-        flushed = flushed + #chunk
-        if flushed >= CLIENT_FLUSH_BYTES then ngx.flush(true); flushed = 0 end
-      end
-    end
-  elseif res.body then
-    local okp = pcall(ngx.print, res.body); if okp then ngx.flush(true) end
-  end
-  -- Final flush
-  ngx.flush(true)
-  httpc:close()
-  return
-end
-
--- HEAD helper: follow redirects; never expose Location; no body
-local function head_no_cache(url)
-  set_var_safe("sc_decision", "HEAD_NOCACHE")
-  local scheme, host, port, path, host_header = parse_url(url)
-  if not scheme then return ngx.exit(ngx.HTTP_BAD_GATEWAY) end
-
-  local httpc = http.new()
-  httpc:set_timeouts(3000, 3000, 3000)
-
-  local function connect_to(h, p, sch)
-    local ok, err = httpc:connect(h, p)
-    if not ok then ngx.log(ngx.WARN,"[streamcache] head connect failed: ",tostring(err)); return nil end
-    if sch == "https" then
-      local ok2, err2 = httpc:ssl_handshake(nil, h, SSL_VERIFY)
-      if not ok2 then ngx.log(ngx.WARN,"[streamcache] head TLS failed: ",tostring(err2)); return nil end
-    end
-    return true
-  end
-
-  if not connect_to(host, port, scheme) then httpc:close(); return ngx.exit(ngx.HTTP_BAD_GATEWAY) end
-  local headers = build_client_like_headers(host_header, url)
-
-  local hops, res, rerr = 0, nil, nil
-  while true do
-    res, rerr = httpc:request{ method = "HEAD", path = path, headers = headers }
-    if (not res) or res.status == 405 then
-      headers["Range"] = headers["Range"] or "bytes=0-0"
-      res, rerr = httpc:request{ method = "GET", path = path, headers = headers }
-    end
-    if not res then httpc:close(); return ngx.exit(ngx.HTTP_BAD_GATEWAY) end
-    if (res.status == 301 or res.status == 302 or res.status == 303 or res.status == 307 or res.status == 308) then
-      if hops >= 5 then httpc:close(); return ngx.exit(ngx.HTTP_BAD_GATEWAY) end
-      local loc = res.headers and (res.headers["Location"] or res.headers["location"])
-      httpc:close()
-      local next_url = resolve_location(url, scheme, host_header, loc)
-      if not next_url then return ngx.exit(ngx.HTTP_BAD_GATEWAY) end
-      url = next_url
-      scheme, host, port, path, host_header = parse_url(url)
-      if not scheme then return ngx.exit(ngx.HTTP_BAD_GATEWAY) end
-      if not connect_to(host, port, scheme) then httpc:close(); return ngx.exit(ngx.HTTP_BAD_GATEWAY) end
-      headers["Host"] = host_header
-      hops = hops + 1
-    else
-      break
-    end
-  end
-
-  local hcopy = {}
-  for k,v in pairs(res.headers or {}) do
-    local kl = string.lower(k)
-    if kl ~= "transfer-encoding" and kl ~= "connection" and kl ~= "keep-alive"
-       and kl ~= "proxy-authenticate" and kl ~= "proxy-authorization"
-       and kl ~= "te" and kl ~= "trailer" and kl ~= "upgrade"
-       and kl ~= "location" then
-      hcopy[k]=v
-    end
-  end
-  hcopy["Accept-Ranges"] = "bytes"
-  ngx.status = ngx.HTTP_OK
-  for k,v in pairs(hcopy) do ngx.header[k]=v end
-  ngx.send_headers()
-  httpc:close()
-  return
-end
-
--- ===================== Tee: upstream -> client + file (strict commit) =====================
--- send_to_client = true (default): original behavior (sets headers & streams to client)
--- send_to_client = false        : writer-only mode (no client headers/prints); just writes .part & updates progress/totals
-local function tee_stream(final_url, dest_path, key, use_range_0, orig_url_for_ref, send_to_client)
-  if send_to_client == nil then send_to_client = true end
-  set_var_safe("sc_decision", "MISS_TEE")
-  final_url = (final_url or ""):gsub("^%s+", ""):gsub("[%s\r\n]+$", "")
-  local scheme, host, port, path, host_header = parse_url(final_url)
-  if not scheme then ngx.log(ngx.WARN,"[streamcache] tee parse failed url=",tostring(final_url)); return fail_exit(ngx.HTTP_BAD_GATEWAY, nil, key, nil, send_to_client) end
-
-  local httpc = http.new()
-  httpc:set_timeouts(5000, 5000, 0)
-
-  local function connect_to(h, p, sch)
-    local ok, err = httpc:connect(h, p)
-    if not ok then ngx.log(ngx.WARN,"[streamcache] tee connect failed: ",tostring(err)); return nil end    
-    if sch == "https" then
-      local ok2, err2 = httpc:ssl_handshake(nil, h, SSL_VERIFY)
-      if not ok2 then ngx.log(ngx.WARN,"[streamcache] tee TLS failed: ",tostring(err2)); return nil end
-    end
-    return true
-  end
-
-  if not connect_to(host, port, scheme) then return fail_exit(ngx.HTTP_BAD_GATEWAY, httpc, key, nil, send_to_client) end
-
-  local headers
-  if send_to_client then
-    headers = build_client_like_headers(host_header, orig_url_for_ref)
-    local ch = ngx.req.get_headers()
-    if ch["Range"] and ch["Range"] ~= "" then
-      headers["Range"] = ch["Range"]
-    elseif use_range_0 then
-      headers["Range"] = "bytes=0-"
-    else
-      headers["Range"] = nil
-    end
-  else
-    -- writer-only: decide Range solely by policy, not by request headers
-    headers = { ["Host"] = host_header, ["User-Agent"] = "EmbyStreamCache/1.0" }
-    if use_range_0 then headers["Range"] = "bytes=0-" end
-  end
-
-  local hops, res, rerr = 0, nil, nil
-  while true do
-    res, rerr = httpc:request{ method = "GET", path = path, headers = headers }
-    if not res then ngx.log(ngx.WARN,"[streamcache] tee request failed: ",tostring(rerr)); return fail_exit(ngx.HTTP_BAD_GATEWAY, httpc, key, nil, send_to_client) end
-    if (res.status == 301 or res.status == 302 or res.status == 303 or res.status == 307 or res.status == 308) then
-      if hops >= 5 then ngx.log(ngx.WARN,"[streamcache] tee too many redirects"); return fail_exit(ngx.HTTP_BAD_GATEWAY, httpc, key, nil, send_to_client) end
-      local loc = res.headers and (res.headers["Location"] or res.headers["location"])
-      httpc:close()
-      local next_url = resolve_location(final_url, scheme, host_header, loc)
-      if not next_url then return fail_exit(ngx.HTTP_BAD_GATEWAY, httpc, key, nil, send_to_client) end
-      final_url = next_url
-      scheme, host, port, path, host_header = parse_url(final_url)
-      if not scheme then return fail_exit(ngx.HTTP_BAD_GATEWAY, httpc, key, nil, send_to_client) end
-      if not connect_to(host, port, scheme) then return fail_exit(ngx.HTTP_BAD_GATEWAY, httpc, key, nil, send_to_client) end
-
-      headers["Host"] = host_header
-      hops = hops + 1
-    else
-      break
-    end
-  end
-
-  -- Range-hostile fallback: single retry without Range
-  if not (res.status == 200 or res.status == 206) then
-    if headers["Range"] and (res.status == 416 or res.status == 400 or res.status == 403) then
-      headers["Range"] = nil
-      res:read_body()
-      httpc:close()
-      -- NEW: Probe expected size via HEAD/0-0 just before retrying GET
-      local probe_hdrs = build_client_like_headers(host_header, orig_url_for_ref)
-      local expected_head, ranges_ok = probe_total_with_head(final_url, probe_hdrs)
-      if expected_head and expected_head > 0 then
-        totals:set(key, expected_head, TOTALS_TTL_SECS)
-        if VERBOSE then ngx.log(ngx.INFO, "[streamcache] fallback expected=", tostring(expected_head), " (", b2human(expected_head), ") ranges=", tostring(ranges_ok)) end
-      else
-        totals:delete(key)
-        if VERBOSE then ngx.log(ngx.INFO, "[streamcache] fallback could not determine expected size; will stream but not commit") end
-      end
-      if not connect_to(host, port, scheme) then return fail_exit(ngx.HTTP_BAD_GATEWAY, httpc, key, nil, send_to_client) end
-      res, rerr = httpc:request{ method = "GET", path = path, headers = headers }
-    end
-    if not res or not (res.status == 200 or res.status == 206) then
-      ngx.log(ngx.WARN,"[streamcache] tee status not OK: ", res and res.status or tostring(rerr))
-      return fail_exit(ngx.HTTP_BAD_GATEWAY, httpc, key, nil, send_to_client)
-    end
-
-  end
-
-  -- Parse totals (size hint)
-  local hl = {}; for k,v in pairs(res.headers or {}) do hl[string.lower(k)] = v end
-  local total_size = nil
-  if hl["content-range"] then
-    local s0,e0,t0 = hl["content-range"]:match("^bytes%s+(%d+)%-(%d+)/(%d+)$")
-    if t0 then total_size = tonumber(t0) end
-  end
-  if not total_size and hl["content-length"] and res.status == 200 then
-    total_size = tonumber(hl["content-length"])
-  end
-  if total_size and total_size > 0 then refresh_totals(key, total_size) end
-
-  -- Prepare response headers to client (only if send_to_client); normalize 206->200 if no client Range
-  if send_to_client then
-    local ch = ngx.req.get_headers()
-    local client_sent_range = (ch["Range"] ~= nil)
-    local hcopy = {}
-    for k,v in pairs(res.headers or {}) do
-      local kl = string.lower(k)
-      if kl ~= "transfer-encoding" and kl ~= "connection" and kl ~= "keep-alive"
-         and kl ~= "proxy-authenticate" and kl ~= "proxy-authorization"
-         and kl ~= "te" and kl ~= "trailer" and kl ~= "upgrade"
-         and kl ~= "location" then
-        hcopy[k] = v
-      end
-    end
-    hcopy["Accept-Ranges"] = "bytes"
-    if (not client_sent_range) and res.status == 206 then
-      hcopy["Content-Range"] = nil
-      if total_size and total_size > 0 then
-        hcopy["Content-Length"] = tostring(total_size)
-      else
-        hcopy["Content-Length"] = nil
-      end
-      ngx.status = ngx.HTTP_OK
-    else
-      ngx.status = res.status
-    end
-    for k,v in pairs(hcopy) do ngx.header[k] = v end
-    ngx.send_headers()
-  end
-
-  -- Open temp file & tee (with no-cache fallback)
-  os.execute("mkdir -p /var/cache/streamcache/tmp")
-  local tmp = "/var/cache/streamcache/tmp/" .. key .. ".part"
-  os.remove(tmp) -- best-effort cleanup from prior crashes
-  local f = io.open(tmp, "wb")
-  if not f then
-    ngx.log(ngx.ERR,"[streamcache] tee cannot open temp: ", tmp, " ; falling back")
-    return fail_exit(ngx.HTTP_BAD_GATEWAY, httpc, key, nil, send_to_client)
-  end
-
-  local total = 0
-  local last_report = 0
-  local client_alive = send_to_client
-  local flushed = 0
-
-  if res.body_reader then
-    while true do
-      local chunk, cerr = res.body_reader(32768)
-      if cerr then ngx.log(ngx.WARN,"[streamcache] tee read error: ",tostring(cerr)); f:close(); return fail_exit(ngx.HTTP_BAD_GATEWAY, httpc, key, tmp, send_to_client) end
-      if not chunk then break end
-      total = total + #chunk
-      local okw, errw = f:write(chunk)
-      if not okw then ngx.log(ngx.ERR,"[streamcache] write failed: ", tostring(errw), " rid=", RID); f:close(); return fail_exit(ngx.HTTP_BAD_GATEWAY, httpc, key, tmp, send_to_client) end
-      if (total - last_report) >= PROGRESS_FLUSH_BYTES then
-        local okf, errf = pcall(function() return f:flush() end)
-        if not okf then ngx.log(ngx.WARN,"[streamcache] flush failed: ", tostring(errf)) end
-        progress:set(key, total, 900); last_report = total
-        local exp = totals:get(key); if exp then refresh_totals(key, tonumber(exp)) end
-      end
-      if client_alive then
-        local okp = pcall(ngx.print, chunk)
-        if not okp then
-          client_alive=false
-        else
-          flushed = flushed + #chunk
-          if flushed >= CLIENT_FLUSH_BYTES then ngx.flush(true); flushed = 0 end
-        end
-      end
-    end
-  elseif res.body then
-    total = #res.body
-    local okw, errw = f:write(res.body)
-    if not okw then ngx.log(ngx.ERR,"[streamcache] write failed: ", tostring(errw), " rid=", RID); f:close(); return fail_exit(ngx.HTTP_BAD_GATEWAY, httpc, key, tmp, send_to_client) end
-    local okf, errf = pcall(function() return f:flush() end)
-    if not okf then ngx.log(ngx.WARN,"[streamcache] flush failed: ", tostring(errf)) end
-    progress:set(key, total, 900)
-    local exp = totals:get(key); if exp then refresh_totals(key, tonumber(exp)) end
-    if client_alive then pcall(ngx.print, res.body); ngx.flush(true) end
-  end
-  if client_alive then ngx.flush(true) end
-
-  local okf2, errf2 = pcall(function() return f:flush() end)
-  if not okf2 then ngx.log(ngx.WARN,"[streamcache] flush failed: ", tostring(errf2)) end
-  progress:set(key, total, 900)
-  local exp2 = totals:get(key); if exp2 then refresh_totals(key, tonumber(exp2)) end
-  f:close(); httpc:close()
-
-  -- Strict commit: only if expected size is known and fully matched
-  local expected = tonumber(totals:get(key) or 0)
-  if expected > 0 then
-    if total == expected then
-      local okr, errr = os.rename(tmp, dest_path)
-      if not okr then
-        ngx.log(ngx.ERR,"[streamcache] commit rename failed: ", tostring(errr),
-        " tmp=", tmp, " dest=", dest_path, " rid=", RID)
-        -- Best-effort copy fallback then remove tmp
-        local src = io.open(tmp, "rb"); local dst = io.open(dest_path, "wb")
-        if src and dst then
-          local buf = src:read("*a"); if buf then dst:write(buf) end
-          dst:close(); src:close(); os.remove(tmp)
-        end
-      end
-      local ts = ngx.now(); write_meta(key, total, ts); access:set(key, ts)
-      jlog(ngx.NOTICE, "tee_complete", {size=b2human(total), expected=expected})
-    else
-      os.remove(tmp)
-      ngx.log(ngx.WARN,"[streamcache] not committing (truncated): written=", tostring(total),
-      " expected=", tostring(expected), " key=", key)
-    end
-  else
-    -- Unknown expected size => do not commit to cache
-    if total > 0 then
-      os.remove(tmp)
-      ngx.log(ngx.WARN,"[streamcache] not committing (unknown total size); key=", key, " written=", tostring(total))
-    else
-      os.remove(tmp); ngx.log(ngx.WARN,"[streamcache] tee produced 0 bytes; not committing key=", key)
-    end
-  end
-  inflight:delete(key)
-  return
-end
-
--- Tee with near-start window: fetch 0-; cache full; serve client slice only (strict commit)
--- (now also supports send_to_client=false, though we do not use it for writer)
-local function tee_stream_range_window(final_url, dest_path, key, client_start, client_end, orig_url_for_ref, send_to_client)
-  if send_to_client == nil then send_to_client = true end
-  set_var_safe("sc_decision", "MISS_TEE_WINDOW")
-  final_url = (final_url or ""):gsub("^%s+", ""):gsub("[%s\r\n]+$", "")
-  local scheme, host, port, path, host_header = parse_url(final_url)
-  if not scheme then ngx.log(ngx.WARN,"[streamcache] tee-window parse failed url=",tostring(final_url)); return fail_exit(ngx.HTTP_BAD_GATEWAY, nil, key, nil, send_to_client) end
-
-  local httpc = http.new()
-  httpc:set_timeouts(5000, 5000, 0)
-
-  local function connect_to(h, p, sch)
-    local ok, err = httpc:connect(h, p)
-    if not ok then ngx.log(ngx.WARN,"[streamcache] tee-window connect failed: ",tostring(err)); return nil end
-    if sch == "https" then
-      local ok2, err2 = httpc:ssl_handshake(nil, h, SSL_VERIFY)
-      if not ok2 then ngx.log(ngx.WARN,"[streamcache] tee-window TLS failed: ",tostring(err2)); return nil end
-    end
-    return true
-  end
-
-  if not connect_to(host, port, scheme) then return fail_exit(ngx.HTTP_BAD_GATEWAY, httpc, key, nil, send_to_client) end
-
-  local ch = ngx.req.get_headers()
-  local headers = build_client_like_headers(host_header, orig_url_for_ref)
-  headers["Range"] = ch["Range"] or "bytes=0-"
-
-  local hops, res, rerr = 0, nil, nil
-  while true do
-    res, rerr = httpc:request{ method = "GET", path = path, headers = headers }
-    if not res then ngx.log(ngx.WARN,"[streamcache] tee-window request failed: ",tostring(rerr)); return fail_exit(ngx.HTTP_BAD_GATEWAY, httpc, key, nil, send_to_client) end
-    if (res.status == 301 or res.status == 302 or res.status == 303 or res.status == 307 or res.status == 308) then
-      if hops >= 5 then ngx.log(ngx.WARN,"[streamcache] tee-window too many redirects"); return fail_exit(ngx.HTTP_BAD_GATEWAY, httpc, key, nil, send_to_client) end
-      local loc = res.headers and (res.headers["Location"] or res.headers["location"])
-      httpc:close()
-      local next_url = resolve_location(final_url, scheme, host_header, loc)
-      if not next_url then return fail_exit(ngx.HTTP_BAD_GATEWAY, httpc, key, nil, send_to_client) end
-      final_url = next_url
-      scheme, host, port, path, host_header = parse_url(final_url)
-      if not scheme then return fail_exit(ngx.HTTP_BAD_GATEWAY, httpc, key, nil, send_to_client) end
-      if not connect_to(host, port, scheme) then return fail_exit(ngx.HTTP_BAD_GATEWAY, httpc, key, nil, send_to_client) end
-      headers["Host"] = host_header
-      hops = hops + 1
-    else
-      break
-    end
-  end
-
-  -- Range-hostile fallback
-  if not (res.status == 200 or res.status == 206) then
-    if headers["Range"] and (res.status == 416 or res.status == 400 or res.status == 403) then
-      headers["Range"] = nil
-      res:read_body()
-      httpc:close()
-      -- NEW: Probe expected size via HEAD/0-0 before fallback GET
-      local probe_hdrs = build_client_like_headers(host_header, orig_url_for_ref)
-      local expected_head, ranges_ok = probe_total_with_head(final_url, probe_hdrs)
-      if expected_head and expected_head > 0 then
-        totals:set(key, expected_head, TOTALS_TTL_SECS)
-        if VERBOSE then ngx.log(ngx.INFO, "[streamcache] window fallback expected=", tostring(expected_head), " (", b2human(expected_head), ") ranges=", tostring(ranges_ok)) end
-      else
-        totals:delete(key)
-        if VERBOSE then ngx.log(ngx.INFO, "[streamcache] window fallback could not determine expected size; will stream but not commit") end
-      end
-      if not connect_to(host, port, scheme) then return fail_exit(ngx.HTTP_BAD_GATEWAY, httpc, key, nil, send_to_client) end
-      res, rerr = httpc:request{ method = "GET", path = path, headers = headers }
-    end
-    if not res or not (res.status == 200 or res.status == 206) then
-      ngx.log(ngx.WARN,"[streamcache] tee-window status not OK: ", res and res.status or tostring(rerr))
-      return fail_exit(ngx.HTTP_BAD_GATEWAY, httpc, key, nil, send_to_client)
-    end
-
-  end
-
-  -- Determine total size
-  local headers_l = {}; for k,v in pairs(res.headers or {}) do headers_l[string.lower(k)] = v end
-  local total_size = nil
-  if headers_l["content-range"] then
-    local s0,e0,t0 = headers_l["content-range"]:match("^bytes%s+(%d+)%-(%d+)/(%d+)$")
-    if s0 and tonumber(s0) == 0 and e0 and t0 then total_size = tonumber(t0) end
-  end
-  if not total_size and headers_l["content-length"] and res.status == 200 then
-    total_size = tonumber(headers_l["content-length"])
-  end
-  if total_size and total_size > 0 then refresh_totals(key, total_size) end
-
-  if not total_size or total_size <= 0 then
-    httpc:close(); inflight:delete(key)
-    return stream_no_cache(final_url, false)
-  end
-
-  -- Compute outbound client range to serve
-  local send_start = math.max(0, tonumber(client_start) or 0)
-  local send_end   = tonumber(client_end)
-  if not send_end or send_end > (total_size - 1) then send_end = total_size - 1 end
-  if send_start > send_end then
-    httpc:close(); inflight:delete(key)
-    ngx.header["Content-Range"] = string.format("bytes */%d", total_size)
-    return ngx.exit(ngx.HTTP_REQUESTED_RANGE_NOT_SATISFIABLE)
-  end
-  local send_len = (send_end - send_start + 1)
-
-  if send_to_client then
-    -- Prepare 206 headers to client
-    local hcopy = {}
-    for k,v in pairs(res.headers or {}) do
-      local kl = string.lower(k)
-      if kl == "content-type" or kl == "etag" or kl == "last-modified" or kl == "content-disposition" then
-        hcopy[k] = v
-      end
-    end
-    hcopy["Accept-Ranges"] = "bytes"
-    hcopy["Content-Range"] = string.format("bytes %d-%d/%d", send_start, send_end, total_size)
-    hcopy["Content-Length"] = tostring(send_len)
-    ngx.status = ngx.HTTP_PARTIAL_CONTENT
-    for k,v in pairs(hcopy) do ngx.header[k] = v end
-    ngx.send_headers()
-  end
-
-  -- Open temp & stream windowed slice while caching full body (with no-cache fallback)
-  os.execute("mkdir -p /var/cache/streamcache/tmp")
-  local tmp = "/var/cache/streamcache/tmp/" .. key .. ".part"
-  os.remove(tmp)
-  local f = io.open(tmp, "wb")
-  if not f then
-    ngx.log(ngx.ERR,"[streamcache] tee-window cannot open temp: ", tmp, " ; falling back to streaming without cache")
-    local pos = 0
-    local function maybe_send_slice(chunk, chunk_start)
-      local chunk_len = #chunk
-      local chunk_end = chunk_start + chunk_len - 1
-      if chunk_end < send_start or chunk_start > send_end then return 0 end
-      local from = math.max(send_start - chunk_start, 0) + 1
-      local to   = math.min(send_end - chunk_start + 1, chunk_len)
-      local slice = chunk:sub(from, to)
-      if send_to_client and #slice > 0 then pcall(ngx.print, slice) end -- batched below
-      return #slice
-    end
-    local flushed_nc = 0
-    if res.body_reader then
-      while true do
-        local chunk, cerr = res.body_reader(32768)
-        if cerr then ngx.log(ngx.WARN,"[streamcache] read error (window nocache fallback): ", tostring(cerr)); httpc:close(); inflight:delete(key); return ngx.exit(ngx.HTTP_BAD_GATEWAY) end
-        if not chunk then break end
-        maybe_send_slice(chunk, pos)
-        pos = pos + #chunk
-        if send_to_client then
-          flushed_nc = flushed_nc + #chunk
-          if flushed_nc >= CLIENT_FLUSH_BYTES then ngx.flush(true); flushed_nc = 0 end
-        end
-      end
-    elseif res.body then
-      maybe_send_slice(res.body, pos); if send_to_client then ngx.flush(true) end
-    end
-    if send_to_client then ngx.flush(true) end
-    httpc:close(); inflight:delete(key); return
-  end
-
-  local total_written, last_report, sent, pos = 0, 0, 0, 0
-  local function maybe_send_slice(chunk, chunk_start)
-    local chunk_len = #chunk
-    local chunk_end = chunk_start + chunk_len - 1
-    if chunk_end < send_start or chunk_start > send_end then return 0 end
-    local from = math.max(send_start - chunk_start, 0) + 1
-    local to   = math.min(send_end - chunk_start + 1, chunk_len)
-    local slice = chunk:sub(from, to)
-    if send_to_client and #slice > 0 then pcall(ngx.print, slice) end -- no per-slice flush; batched below
-    return #slice
-  end
-
-  local flushed2 = 0
-  if res.body_reader then
-    while true do
-      local chunk, cerr = res.body_reader(32768)
-      if cerr then ngx.log(ngx.WARN,"[streamcache] tee-window read error: ",tostring(cerr)); f:close(); return fail_exit(ngx.HTTP_BAD_GATEWAY, httpc, key, tmp, send_to_client) end
-      if not chunk then break end
-      total_written = total_written + #chunk
-      local okw, errw = f:write(chunk)
-      if not okw then ngx.log(ngx.ERR,"[streamcache] write failed: ", tostring(errw), " rid=", RID); f:close(); return fail_exit(ngx.HTTP_BAD_GATEWAY, httpc, key, tmp, send_to_client) end
-      if (total_written - last_report) >= PROGRESS_FLUSH_BYTES then
-        local okf, errf = pcall(function() return f:flush() end)
-        if not okf then ngx.log(ngx.WARN,"[streamcache] flush failed: ", tostring(errf)) end
-        progress:set(key, total_written, 900); last_report = total_written
-        local exp = totals:get(key); if exp then refresh_totals(key, tonumber(exp)) end
-      end
-      sent = sent + maybe_send_slice(chunk, pos)
-      pos  = pos  + #chunk
-
-      if send_to_client then
-        flushed2 = flushed2 + #chunk
-        if flushed2 >= CLIENT_FLUSH_BYTES then ngx.flush(true); flushed2 = 0 end
-      end
-    end
-  elseif res.body then
-    local chunk = res.body
-    total_written = #chunk
-    local okw, errw = f:write(chunk)
-    if not okw then ngx.log(ngx.ERR,"[streamcache] write failed: ", tostring(errw), " rid=", RID); f:close(); return fail_exit(ngx.HTTP_BAD_GATEWAY, httpc, key, tmp, send_to_client) end
-    local okf, errf = pcall(function() return f:flush() end)
-    if not okf then ngx.log(ngx.WARN,"[streamcache] flush failed: ", tostring(errf)) end
-    progress:set(key, total_written, 900)
-    local exp = totals:get(key); if exp then refresh_totals(key, tonumber(exp)) end
-    sent = sent + maybe_send_slice(chunk, pos)
-    pos  = pos  + #chunk
-  end
-  if send_to_client then ngx.flush(true) end
-
-  local okf2, errf2 = pcall(function() return f:flush() end)
-  if not okf2 then ngx.log(ngx.WARN,"[streamcache] flush failed: ", tostring(errf2)) end
-  progress:set(key, total_written, 900)
-  local exp2 = totals:get(key); if exp2 then refresh_totals(key, tonumber(exp2)) end
-  f:close(); httpc:close()
-
-  -- Commit strictly only if complete
-  local expected = tonumber(totals:get(key) or 0)
-  if expected > 0 and total_written == expected then
-    local okr, errr = os.rename(tmp, dest_path)
-    if not okr then
-      ngx.log(ngx.ERR,"[streamcache] commit rename failed: ", tostring(errr),
-      " tmp=", tmp, " dest=", dest_path, " rid=", RID)
-      local src = io.open(tmp, "rb"); local dst = io.open(dest_path, "wb")
-      if src and dst then
-        local buf = src:read("*a"); if buf then dst:write(buf) end
-        dst:close(); src:close(); os.remove(tmp)
-      end
-    end
-    local ts = ngx.now(); write_meta(key, total_written, ts); access:set(key, ts)
-    jlog(ngx.NOTICE, "tee_window_complete", {
-      size=b2human(total_written),
-      served=tostring(sent),
-      start=tostring(send_start),
-      stop=tostring(send_end)
-    })
-  else
-    os.remove(tmp)
-    if expected > 0 then
-      ngx.log(ngx.WARN,"[streamcache] not committing (truncated): written=", tostring(total_written),
-      " expected=", tostring(expected), " key=", key)
-    else
-      ngx.log(ngx.WARN,"[streamcache] not committing (unknown total size); key=", key,
-      " written=", tostring(total_written))
-    end
-  end
-
-  inflight:delete(key)
-  return
-end
-
--- ===================== Follower (serve from .part) =====================
-local function serve_from_part(final_url, key, req_start, req_end)
-  local files_dir = "/var/cache/streamcache/files"
-  local tmp = "/var/cache/streamcache/tmp/" .. key .. ".part"
-  if file_exists(files_dir .. "/" .. key) then
-    ngx.header["X-Cache"] = "HIT"
-    set_var_safe("sc_decision", "HIT")
-    return ngx.exec("/cache/" .. key)
-  end
-  local f = io.open(tmp, "rb")
-  if not f then return nil, "no_part" end
-  local total_size = totals:get(key)
-  local waited = 0
-  while not total_size and waited < 2000 do ngx.sleep(0.05); waited = waited + 50; total_size = totals:get(key) end
-  if not total_size then f:close(); return nil, "no_total" end
-  total_size = tonumber(total_size)
-  local start = tonumber(req_start) or 0
-  local stop  = (req_end and req_end ~= "") and tonumber(req_end) or (total_size - 1)
-  if stop > (total_size - 1) then stop = total_size - 1 end
-  if start > stop or start > total_size - 1 then
-    f:close(); ngx.header["Content-Range"] = string.format("bytes */%d", total_size)
-    return ngx.exit(ngx.HTTP_REQUESTED_RANGE_NOT_SATISFIABLE)
-  end
-  local oh = fetch_origin_headers(final_url, build_client_like_headers(nil, final_url))
-  ngx.status = ngx.HTTP_PARTIAL_CONTENT
-  ngx.header["X-Cache"] = "FOLLOW"
-  set_var_safe("sc_decision", "FOLLOW")
-  ngx.header["Accept-Ranges"]  = "bytes"
-  ngx.header["Content-Range"]  = string.format("bytes %d-%d/%d", start, stop, total_size)
-  ngx.header["Content-Length"] = tostring(stop - start + 1)
-  if oh["content-type"]        then ngx.header["Content-Type"]        = oh["content-type"] end
-  if oh["etag"]                then ngx.header["ETag"]               = oh["etag"]          end
-  if oh["last-modified"]       then ngx.header["Last-Modified"]      = oh["last-modified"] end
-  if oh["content-disposition"] then ngx.header["Content-Disposition"]= oh["content-disposition"] end
-  ngx.send_headers()
-
-  local deadline = ngx.now() + FOLLOWER_WAIT_MAX
-    -- New logic: wait until at least FOLLOWER_MIN_BYTES are available or timeout
-    local waited_bytes = 0
-    while (progress:get(key) or 0) < FOLLOWER_MIN_BYTES and ngx.now() < deadline do
-        ngx.sleep(FOLLOWER_POLL_MS / 1000)
-    end
-  local sent, needed, current_offset = 0, (stop - start + 1), start
-  f:seek("set", start)
-  local function available_bytes()
-    local p = progress:get(key) or 0
-    local avail = p - current_offset
-    if avail < 0 then avail = 0 end
-    local max_need = (stop + 1) - current_offset
-    if avail > max_need then avail = max_need end
-    return avail
-  end
-  while sent < needed do
-    local avail = available_bytes()
-    if avail > 0 then
-      local chunk_sz = math.min(avail, 8192)
-      local chunk = f:read(chunk_sz)
-      if not chunk or #chunk == 0 then
-        ngx.sleep(FOLLOWER_POLL_MS / 1000)
-      else
-        local okp = pcall(ngx.print, chunk); if not okp then f:close(); return ngx.exit(ngx.HTTP_OK) end
-        ngx.flush(true)
-        sent = sent + #chunk
-        current_offset = current_offset + #chunk
-      end
-    else
-      if ngx.now() > deadline then
-        f:close(); ngx.log(ngx.WARN,"[streamcache] follower timeout key=", key, " offset=", tostring(current_offset))
-        return ngx.exit(ngx.HTTP_GATEWAY_TIMEOUT)
-      end
-      ngx.sleep(FOLLOWER_POLL_MS / 1000)
-    end
-  end
-  f:close()
-  return
-end
-
--- Helper: brief wait-and-follow to avoid duplicate no-cache origin pulls
-local function try_follow_with_wait(orig, key, req_start, req_end)
-  local deadline = ngx.now() + (FOLLOWER_START_WAIT_MS / 1000)
-  while true do
-    local err = serve_from_part(orig, key, req_start, req_end)
-    if not err then return true end                         -- follow succeeded
-    if ngx.now() >= deadline then return false, err end     -- give up after short wait
-    if err ~= "no_part" and err ~= "no_total" then          -- non-retryable reason
-      return false, err
-    end
-    ngx.sleep(0.05)
-  end
-end
-
--- ===================== Entry (HEAD-safe + policy) =====================
-
--- Decode Base64URL
-local b64  = ngx.var.b64
-local orig = b64 and b64url_decode(b64) or nil
+--
+-- Request flow:
+--   1. Decode/validate URL
+--   2. Allowed hosts check
+--   3. Non-GET → head passthrough
+--   4. Cache HIT → serve from disk
+--   5. Parse Range header
+--   6. Far seek (> threshold) → stream_no_cache
+--   7. Writer election (inflight:add)
+--      - Already inflight → follower
+--      - New writer → background timer + client follows
+--   8. Timer fallback → inline tee
+
+local Config   = require "sc_config"
+local Utils    = require "sc_utils"
+local File     = require "sc_file"
+local Upstream = require "sc_upstream"
+local NoCache  = require "sc_nocache"
+local Tee      = require "sc_tee"
+local Follower = require "sc_follower"
+
+local ngx = ngx
+
+-- ======================== Bootstrap ========================
+local cfg = Config.load()
+
+local ctx = {
+  config = cfg,
+  shared = {
+    inflight = ngx.shared.inflight,
+    access   = ngx.shared.access,
+    resolved = ngx.shared.resolved,
+    progress = ngx.shared.progress,
+    totals   = ngx.shared.totals,
+  },
+}
+
+-- ======================== URL Decode & Validate ========================
+local b64 = ngx.var.b64
+local orig = b64 and Utils.b64url_decode(b64) or nil
 if not orig or not orig:match("^https?://") then
-  ngx.log(ngx.WARN,"[streamcache] bad request (invalid or non-http URL)")
+  ngx.log(ngx.WARN, "[streamcache] bad request (invalid or non-http URL)")
   return ngx.exit(ngx.HTTP_BAD_REQUEST)
 end
-orig = orig:gsub("^%s+",""):gsub("[%s\r\n]+$","")
+orig = orig:gsub("^%s+", ""):gsub("[%s\r\n]+$", "")
 
--- Optional SSRF allowlist
-local allowed = os.getenv("ALLOWED_HOSTS")
-if allowed and allowed ~= "" then
+ctx.url = orig
+ctx.rid = ngx.var.request_id or tostring(ngx.now())
+ctx.key = Utils.key_from_url(orig)
+
+-- ======================== Allowed Hosts ========================
+if cfg.ALLOWED_HOSTS and cfg.ALLOWED_HOSTS ~= "" then
   local host = orig:match("^https?://([^/]+)")
-  local ok=false; for h in allowed:gmatch("[^,%s]+") do if host==h then ok=true; break end end
-  if not ok then ngx.status=ngx.HTTP_FORBIDDEN; ngx.say("Host not allowed"); return end
+  local allowed = false
+  for h in cfg.ALLOWED_HOSTS:gmatch("[^,%s]+") do
+    if host == h then allowed = true; break end
+  end
+  if not allowed then
+    ngx.status = ngx.HTTP_FORBIDDEN
+    ngx.say("Host not allowed")
+    return
+  end
 end
 
+-- ======================== Non-GET Methods ========================
 local method = ngx.req.get_method()
 if method ~= "GET" then
-  -- HEAD/OPTIONS/etc: no tee, no inflight; never expose 30x
-  return head_no_cache(orig)
+  return NoCache.head(orig, cfg)
 end
 
-local files_dir = "/var/cache/streamcache/files"
-os.execute("mkdir -p " .. files_dir .. " /var/cache/streamcache/tmp /var/cache/streamcache/meta")
-local key        = key_from_url(orig)
-local final_path = files_dir .. "/" .. key
+-- ======================== Ensure Dirs ========================
+File.ensure_dirs({cfg.CACHE_DIR, cfg.TMP_DIR, cfg.META_DIR})
+local key = ctx.key
+local final_path = cfg.CACHE_DIR .. "/" .. key
 
-local function update_last_access()
-  local ts = ngx.now(); access:set(key, ts); write_meta(key, file_size(final_path), ts)
-end
-
--- HIT (with zero-byte guard)
-if file_exists(final_path) then
-  local sz = file_size(final_path)
+-- ======================== Cache HIT ========================
+if File.exists(final_path) then
+  local sz = File.size(final_path)
   if sz <= 0 then
-    os.remove(final_path); os.remove("/var/cache/streamcache/meta/"..key..".meta"); inflight:delete(key)
+    -- Corrupt zero-byte file: clean up
+    File.remove(final_path)
+    File.remove(cfg.META_DIR .. "/" .. key .. ".meta")
+    ctx.shared.inflight:delete(key)
   else
     ngx.header["X-Cache"] = "HIT"
-    if VERBOSE then ngx.log(ngx.INFO,"[streamcache] HIT key=", key, " size=", b2human(sz)) end
-    ngx.var.sc_decision = "HIT"
-    update_last_access()
+    Utils.set_var_safe("sc_decision", "HIT")
+    if cfg.VERBOSE then
+      ngx.log(ngx.INFO, "[streamcache] HIT key=", key, " size=", Utils.b2human(sz))
+    end
+    -- Update LRU
+    local ts = ngx.now()
+    ctx.shared.access:set(key, ts)
+    File.write_meta(key, sz, ts, cfg.META_DIR)
     return ngx.exec("/cache/" .. key)
   end
 end
 
--- Decide path based on client Range
-local req_range   = ngx.req.get_headers()["Range"]
-local use_range_0 = false
+-- ======================== Parse Range ========================
+local req_range    = ngx.req.get_headers()["Range"]
+local use_range_0  = false
 local near_start, near_end = nil, nil
+
 if not req_range or req_range == "" then
-  -- No Range from client: behave like a player upstream (Range:0-), normalize to 200 for client
+  -- No Range from client: behave like a player upstream (Range:0-)
   use_range_0 = true
 else
   local s, e = req_range:match("^bytes=(%d+)%-([%d%*]*)$")
   if s then
-    s = tonumber(s); e = (e and e ~= "") and tonumber(e) or nil
+    s = tonumber(s)
+    e = (e and e ~= "") and tonumber(e) or nil
     if s == 0 and (not e) then
+      -- bytes=0- : same as no range
       use_range_0 = true
-    elseif s > 0 and s <= RANGE_TEE_THRESHOLD then
+    elseif s > 0 and s <= cfg.RANGE_TEE_THRESHOLD then
+      -- Near-start seek: tee full file, serve windowed slice
       near_start, near_end = s, e
       use_range_0 = true
     else
       -- Far-seek: stream without cache; follow redirects; never expose Location
-      ngx.var.sc_decision = "MISS_NO_CACHE"
-      return stream_no_cache(orig, false)
+      Utils.set_var_safe("sc_decision", "MISS_NO_CACHE")
+      return NoCache.stream(orig, cfg, nil, false)
     end
   else
     -- Malformed Range: treat as no-range
@@ -1015,54 +129,68 @@ else
   end
 end
 
--- Only one writer per key
-local added = inflight:add(key, true, 900)
+-- ======================== Writer Election ========================
+-- Capture client headers BEFORE timer (timer context can't access ngx.req)
+local captured_headers = ngx.req.get_headers()
+
+local added = ctx.shared.inflight:add(key, true, cfg.INFLIGHT_TTL)
 if not added then
-  -- Writer exists. Prefer to FOLLOW from .part for near-start or no-range
+  -- Writer exists: try to follow from .part
   local s, e = nil, nil
   if req_range and req_range ~= "" then
     local s1, e1 = req_range:match("^bytes=(%d+)%-([%d%*]*)$")
-    if s1 then s = tonumber(s1); e = (e1 and e1 ~= "") and tonumber(e1) or nil end
+    if s1 then
+      s = tonumber(s1)
+      e = (e1 and e1 ~= "") and tonumber(e1) or nil
+    end
   end
   if not s then s = 0; e = nil end
-  if s == 0 or s <= RANGE_TEE_THRESHOLD then
-    local ok = try_follow_with_wait(orig, key, s, e)
+
+  if s == 0 or s <= cfg.RANGE_TEE_THRESHOLD then
+    local ok = Follower.try_follow_with_wait(ctx, orig, s, e)
     if ok then return end
-    if VERBOSE then ngx.log(ngx.INFO,"[streamcache] follow not ready; fallback nocache key=", key) end
+    if cfg.VERBOSE then
+      ngx.log(ngx.INFO, "[streamcache] follow not ready; fallback nocache key=", key)
+    end
   end
-  -- Fallback: stream nocache (never leak redirects)
-  set_var_safe("sc_decision", ((not req_range or req_range == "") and "MISS_NO_CACHE") or "MISS_NO_CACHE")
-  return stream_no_cache(orig, (not req_range or req_range == ""))
+  -- Fallback: stream nocache
+  Utils.set_var_safe("sc_decision", "MISS_NO_CACHE")
+  return NoCache.stream(orig, cfg, nil, (not req_range or req_range == ""))
 end
 
--- We are the first request (writer). Start a background writer-only timer
+-- ======================== We Are Writer ========================
+-- Start background writer timer (decoupled from client speed).
+-- Client becomes a follower reading from the growing .part file.
+
 local function start_writer_timer(range0)
   return ngx.timer.at(0, function(premature)
     if premature then return end
-    -- Writer-only: decoupled from client speed
-    tee_stream(orig, final_path, key, range0, orig, false)
+    Tee.tee_stream(ctx, orig, final_path, range0, captured_headers, false)
   end)
 end
 
 local ok_timer, err_timer
--- For best reuse, prefer writing from the start when feasible
 if near_start then
-  ok_timer, err_timer = start_writer_timer(true)   -- force Range: 0-
+  ok_timer, err_timer = start_writer_timer(true) -- force Range: 0-
 else
   ok_timer, err_timer = start_writer_timer(use_range_0)
 end
 
--- If the timer could not be started, fall back to original tee (client-coupled)
+-- If timer could not start, fall back to inline tee (client-coupled)
 if not ok_timer then
-  if VERBOSE then ngx.log(ngx.WARN, "[streamcache] writer timer failed: ", tostring(err_timer), " ; using inline tee") end
+  if cfg.VERBOSE then
+    ngx.log(ngx.WARN, "[streamcache] writer timer failed: ", tostring(err_timer),
+      " ; using inline tee")
+  end
   if near_start then
-    return tee_stream_range_window(orig, final_path, key, near_start, near_end, orig, true)
+    return Tee.tee_stream_range_window(
+      ctx, orig, final_path, near_start, near_end, captured_headers, true)
   else
-    return tee_stream(orig, final_path, key, use_range_0, orig, true)
+    return Tee.tee_stream(ctx, orig, final_path, use_range_0, captured_headers, true)
   end
 end
 
--- Now follow from the .part for this client
+-- ======================== Client Follows Writer ========================
 local follow_start, follow_end = 0, nil
 if req_range and req_range ~= "" then
   local s2, e2 = req_range:match("^bytes=(%d+)%-([%d%*]*)$")
@@ -1072,10 +200,10 @@ if req_range and req_range ~= "" then
   end
 end
 
-local ok_follow = try_follow_with_wait(orig, key, follow_start, follow_end)
+local ok_follow = Follower.try_follow_with_wait(ctx, orig, follow_start, follow_end)
 if ok_follow then
   return
 end
 
--- Last-resort fallback (edge): stream nocache
-return stream_no_cache(orig, (not req_range or req_range == ""))
+-- Last-resort fallback: stream nocache
+return NoCache.stream(orig, cfg, nil, (not req_range or req_range == ""))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - ./conf/nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf:ro
       - ./conf/streamcache.conf:/etc/openresty/conf.d/streamcache.conf:ro
       - ./conf/streamcache.lua:/etc/openresty/streamcache.lua:ro
+      - ./conf/lib:/etc/openresty/lib:ro
       #- ./cache:/var/cache/streamcache
       - /mnt/data/streamcache:/var/cache/streamcache
     command: ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]


### PR DESCRIPTION
Modular Refactor
Complete rewrite from the production monolith (1,081-line streamcache.lua) into a modular architecture across 8 files while preserving all production behavior. Fixes critical bugs, reduces memory usage, and improves upstream detection avoidance.

Architecture
Refactored single-file monolith into 7 modules: sc_config, sc_utils, sc_file, sc_upstream, sc_nocache, sc_tee, sc_follower
Entry point (streamcache.lua) reduced to ~210 lines of routing logic
State flows through a ctx table — no globals
No circular dependencies; clean module dependency graph
All production features preserved: windowed tee, range-hostile fallback, 206→200 normalization, strict commit, writer/follower coordination
Bug Fixes
Incomplete files committed to cache — The copy fallback (cross-filesystem rename) used read("*a") which could OOM on multi-GB files and had no post-copy size verification. Replaced with 1MB chunked copy + size verification after both rename and copy paths.
Inflight lock expiry during slow downloads — The 900s writer lock was never refreshed. Downloads exceeding 15 minutes caused the lock to expire, allowing duplicate writers for the same file. Lock is now refreshed on every progress update.
Memory growth during downloads (OOM) — posix_fadvise(FADV_DONTNEED) was called on dirty pages, which the kernel silently ignores. Added sync_file_range() to flush dirty pages to disk before dropping them. Writer uses a pipelined strategy (start async writeback, drop previous range) every 2MB for zero additional latency.
Memory growth when client disconnects — The background writer ran at wire speed with no pacing after the client disconnected, accumulating dirty pages faster than the kernel could flush. Added ngx.sleep(0) yield when no client is consuming data.
Follower not detecting client disconnect — With lua_check_client_abort off, the follower couldn't detect when Chrome/VLC closed the connection. It would continue reading the entire .part file into page cache. Enabled lua_check_client_abort on with ngx.on_abort() for immediate disconnect detection.
Follower re-caching writer's dropped pages — Follower used io.open/f:read which brought page cache pages back after the writer dropped them. Switched to FFI open()/read() with periodic fadvise(DONTNEED) via drop_read_cache() (no sync_file_range needed for read-only pages).
Follower sending 206 to browsers — Follower always returned 206 Partial Content, even when the client sent no Range header. Chrome rejected this. Now returns 200 OK with full Content-Length when no Range was requested.
ngx.exit(504) after headers sent — When the writer died mid-transfer, the follower tried to change the HTTP status after headers were already sent. Now exits cleanly with ngx.exit(ngx.HTTP_OK).
Detection Avoidance
Real client headers in all paths — The background writer previously sent User-Agent: EmbyStreamCache/1.0. Now captures the actual client headers before starting the timer and forwards them to upstream. All code paths use Upstream.build_client_like_headers().
Browser-like fallback UA — Default User-Agent changed from EmbyStreamCache/1.0 to a generic browser string for cases where no client UA is available.
Additional header forwarding — Now forwards X-Playback-Session-Id, If-Range, If-None-Match, If-Modified-Since to upstream.
Follower HEAD probe eliminated — Writer caches origin response headers (Content-Type, ETag, etc.) in the resolved shared dict. Followers read from cache instead of making an extra HEAD request per viewer. Halves upstream request count for concurrent viewers.
Consistent response header filtering — All response paths use Utils.filter_response_headers() which strips 9 hop-by-hop headers uniformly. Production had inconsistent filtering across different code paths.
Centralized redirect following — Upstream.request() is the single place redirects are followed (up to 5 hops). Eliminates duplicated redirect loops that existed in every streaming function.
Configuration Fixes
CACHE_MAX_BYTES and CACHE_LOW_WATERMARK_BYTES restored to binary values

